### PR TITLE
Update 20180119 No More Ubuntu Debian is the New Choice For Googles In-house Linux Distribution.md

### DIFF
--- a/sources/tech/20180119 No More Ubuntu Debian is the New Choice For Googles In-house Linux Distribution.md
+++ b/sources/tech/20180119 No More Ubuntu Debian is the New Choice For Googles In-house Linux Distribution.md
@@ -1,3 +1,5 @@
+Translating by jessie-pang
+
 No More Ubuntu! Debian is the New Choice For Google’s In-house Linux Distribution
 ============================================================
 


### PR DESCRIPTION
20180119 No More Ubuntu Debian is the New Choice For Googles In-house Linux Distribution.md