### PR TITLE
选题: 20190415 12 Single Board Computers: Alternative to Raspberry Pi

### DIFF
--- a/sources/tech/20190415 12 Single Board Computers- Alternative to Raspberry Pi.md
+++ b/sources/tech/20190415 12 Single Board Computers- Alternative to Raspberry Pi.md
@@ -1,0 +1,354 @@
+[#]: collector: (lujun9972)
+[#]: translator: ( )
+[#]: reviewer: ( )
+[#]: publisher: ( )
+[#]: url: ( )
+[#]: subject: (12 Single Board Computers: Alternative to Raspberry Pi)
+[#]: via: (https://itsfoss.com/raspberry-pi-alternatives/)
+[#]: author: (Ankush Das https://itsfoss.com/author/ankush/)
+
+12 Single Board Computers: Alternative to Raspberry Pi
+======
+
+_**Brief: Looking for a Raspberry Pi alternative? Here are some other single board computers to satisfy your DIY cravings.**_
+
+Raspberry Pi is the most popular single board computer right now. You can use it for your DIY projects or can use it as a cost effective system to learn coding or maybe utilize a [media server software][1] on it to stream media at your convenience.
+
+You can do a lot of things with Raspberry Pi but it is not the ultimate solution for all kinds of tinkerers. Some might be looking for a cheaper board and some might be on the lookout for a powerful one.
+
+Whatever be the case, we do need Raspberry Pi alternatives for a variety of reasons. So, in this article, we will talk about the best ten single board computers that we think are the best Raspberry Pi alternatives.
+
+![][2]
+
+### Raspberry Pi alternatives to satisfy your DIY craving
+
+The list is in no particular order of ranking. Some of the links here are affiliate links. Please read our [affiliate policy][3].
+
+#### 1\. Onion Omega2+
+
+![][4]
+
+For just **$13** , the Omega2+ is one of the cheapest IoT single board computers you can find out there. It runs on LEDE (Linux Embedded Development Environment) Linux OS – a distribution based on [OpenWRT][5].
+
+Its form factor, cost, and the flexibility that comes from running a customized version of Linux OS makes it a perfect fit for almost any type of IoT applications.
+
+You can find [Onion Omega kit on Amazon][6] or order from their own website that would cost you extra shipping charges.
+
+**Key Specifications**
+
+  * MT7688 SoC
+  * 2.4 GHz IEEE 802.11 b/g/n WiFi
+  * 128 MB DDR2 RAM
+  * 32 MB on-board flash storage
+  * MicroSD Slot
+  * USB 2.0
+  * 12 GPIO Pins
+
+
+
+[Visit WEBSITE
+][7]
+
+#### 2\. NVIDIA Jetson Nano Developer Kit
+
+![][8]
+
+This is a very unique and interesting Raspberry Pi alternative from NVIDIA for just **$99**. Yes, it’s not something that everyone can make use of – but for a specific group of tinkerers or developers.
+
+NVIDIA explains it for the following use-case:
+
+> NVIDIA® Jetson Nano™ Developer Kit is a small, powerful computer that lets you run multiple neural networks in parallel for applications like image classification, object detection, segmentation, and speech processing. All in an easy-to-use platform that runs in as little as 5 watts.
+>
+> nvidia
+
+So, basically, if you are into AI and deep learning, you can make use of the developer kit. If you are curious, the production compute module of this will be arriving in June 2019.
+
+**Key Specifications:**
+
+  * CPU: Quad-core ARM A57 @ 1.43 GHz
+  * GPU: 128-core Maxwell
+  * RAM: 4 GB 64-bit LPDDR4 25.6 GB/s
+  * Display: HDMI 2.0
+  * 4 x USB 3.0 and eDP 1.4
+
+
+
+[VISIT WEBSITE
+][9]
+
+#### 3\. ASUS Tinker Board S
+
+![][10]
+
+ASUS Tinker Board S isn’t the most affordable Raspberry Pi alternative at **$82** (on [Amazon][11]) but it is a powerful alternative. It features the same 40-pin connector that you’d normally find in the standard Raspberry Pi 3 Model but offers a powerful processor and a GPU.Also, the size of the Tinker Board S is exactly the same as a standard Raspberry Pi 3.
+
+The main highlight of this board is the presence of 16 GB [eMMC][12] (in layman terms, it has got SSD-like storage on board that makes it faster while working on it).
+
+**Key Specifications:**
+
+  * Rockchip Quad-Core RK3288 processor
+  * 2 GB DDR3 RAM
+  * Integrated Graphics Processor
+  * ARM® Mali™-T764 GPU
+  * 16 GB eMMC
+  * MicroSD Card Slot
+  * 802.11 b/g/n, Bluetooth V4.0 + EDR
+  * USB 2.0
+  * 28 GPIO pins
+  * HDMI Interface
+
+
+
+[Visit website
+][13]
+
+#### 4\. ClockworkPi
+
+![][14]
+
+Clockwork Pi is usually a part of the [GameShell Kit][15] if you are looking to assemble a modular retro gaming console. However, you can purchase the board separately for $49.
+
+Its compact size, WiFi connectivity, and the presence of micro HDMI port make it a great choice for a lot of things.
+
+**Key Specifications:**
+
+  * Allwinner R16-J Quad-core Cortex-A7 CPU @1.2GHz
+  * Mali-400 MP2 GPU
+  * RAM: 1GB DDR3
+  * WiFi & Bluetooth v4.0
+  * Micro HDMI output
+  * MicroSD Card Slot
+
+
+
+[visit website
+][16]
+
+#### 5\. Arduino Mega 2560
+
+![][17]
+
+If you are into robotic projects or you want something for a 3D printer – Arduino Mega 2560 will be a handy replacement to Raspberry Pi. Unlike Raspberry Pi, it is based on a microcontroller and not a microprocessor.
+
+It would cost you $38.50 on their [official site][18] and and around [$33 on Amazon][19].
+
+**Key Specifications:**
+
+  * Microcontroller: ATmega2560
+  * Clock Speed: 16 MHz
+  * Digital I/O Pins: 54
+  * Analog Input Pins: 16
+  * Flash Memory: 256 KB of which 8 KB used by bootloader
+
+
+
+[visit website
+][18]
+
+#### 6\. Rock64 Media Board
+
+![][20]
+
+For the same investment as you would on a Raspberry Pi 3 B+, you will be getting a faster processor and double the memory on Rock64 Media Board. In addition, it also offers a cheaper alternative to Raspberry Pi if you want the 1 GB RAM model – which would cost $10 less.
+
+Unlike Raspberry Pi, you do not have wireless connectivity support here but the presence of USB 3.0 and HDMI 2.0 does make a good difference if that matters to you.
+
+**Key Specifications:**
+
+  * Rockchip RK3328 Quad-Core ARM Cortex A53 64-Bit Processor
+  * Supports up to 4GB 1600MHz LPDDR3 RAM
+  * eMMC module socket
+  * MicroSD Card slot
+  * USB 3.0
+  * HDMI 2.0
+
+
+
+[visit website
+][21]
+
+#### 7\. Odroid-XU4
+
+![][22]
+
+Odroid-XU4 is the perfect alternative to Raspberry Pi if you have room to spend a little more ($80-$100 or even lower, depending on the store/availability).
+
+It is indeed a powerful replacement and technically a bit smaller in size. The support for eMMC and USB 3.0 makes it faster to work with.
+
+**Key Specifications:**
+
+  * Samsung Exynos 5422 Octa ARM Cortex™-A15 Quad 2Ghz and Cortex™-A7 Quad 1.3GHz CPUs
+  * 2Gbyte LPDDR3 RAM
+  * GPU: Mali-T628 MP6
+  * USB 3.0
+  * HDMI 1.4a
+  * eMMC 5.0 module socket
+  * MicroSD Card Slot
+
+
+
+[visit website
+][23]
+
+#### 8\. **PocketBeagle**
+
+![][24]
+
+It is an incredibly small SBC – almost similar to the Raspberry Pi Zero. However, it would cost you the same as that of a full-sized Raspberry Pi 3 model. The main highlight here is that you can use it as a USB key-fob and then access the Linux terminal to work on it.
+
+**Key Specifications:**
+
+  * Processor: Octavo Systems OSD3358 1GHz ARM® Cortex-A8
+  * RAM: 512 MB DDR3
+  * 72 expansion pin headers
+  * microUSB
+  * USB 2.0
+
+
+
+[visit website
+][25]
+
+#### 9\. Le Potato
+
+![][26]
+
+Le Potato by [Libre Computer][27], also identified by its model number AML-S905X-CC. It would [cost you $45][28].
+
+If you want double the memory along with HDMI 2.0 interface by spending a bit more than a Raspberry Pi – this would be the perfect choice. Although, you won’t find wireless connectivity baked in.
+
+**Key Specifications:**
+
+  * Amlogic S905X SoC
+  * 2GB DDR3 SDRAM
+  * USB 2.0
+  * HDMI 2.0
+  * microUSB
+  * MicroSD Card Slot
+  * eMMC Interface
+
+
+
+[visit website
+][29]
+
+#### 10\. Banana Pi M64
+
+![][30]
+
+It comes loaded with 8 Gigs of eMMC – which is the key highlight of this Raspberry Pi alternative. For the very same reason, it would cost you $60.
+
+The presence of HDMI interface makes it 4K-ready. In addition, Banana Pi offers a lot more variety of open source SBCs as an alternative to Raspberry Pi.
+
+**Key Specifications:**
+
+  * 1.2 Ghz Quad-Core ARM Cortex A53 64-Bit Processor-R18
+  * 2GB DDR3 SDRAM
+  * 8 GB eMMC
+  * WiFi & Bluetooth
+  * USB 2.0
+  * HDMI
+
+
+
+[visit website
+][31]
+
+#### 11\. Orange Pi Zero
+
+![][32]
+
+The Orange Pi Zero is an incredibly cheap alternative to Raspberry Pi. You will be able to get it for almost $10 on Aliexpress or Amazon. For a [little more investment, you can get 512 MB RAM][33].
+
+If that isn’t sufficient, you can also go for Orange Pi 3 with better specifications which will cost you around $25.
+
+**Key Specifications:**
+
+  * H2 Quad-core Cortex-A7
+  * Mali400MP2 GPU
+  * RAM: Up to 512 MB
+  * TF Card support
+  * WiFi
+  * USB 2.0
+
+
+
+[Visit website
+][34]
+
+#### 12\. VIM 2 SBC by Khadas
+
+![][35]
+
+VIM 2 by Khadas is one of the latest SBCs that you can grab with Bluetooth 5.0 on board. It [starts from $99 (the basic model) and goes up to $140][36].
+
+The basic model includes 2 GB RAM, 16 GB eMMC and Bluetooth 4.1. However, the Pro/Max versions would include Bluetooth 5.0, more memory, and more eMMC storage.
+
+**Key Specifications:**
+
+  * Amlogic S912 1.5GHz 64-bit Octa-Core CPU
+  * T820MP3 GPU
+  * Up to 3 GB DDR4 RAM
+  * Up to 64 GB eMMC
+  * Bluetooth 5.0 (Pro/Max)
+  * Bluetooth 4.1 (Basic)
+  * HDMI 2.0a
+  * WiFi
+
+
+
+**Wrapping Up**
+
+We do know that there are different types of single board computers. Some are better than Raspberry Pi – and some scaled down versions of it for a cheaper price tag. Also, SBCs like Jetson Nano have been tailored for a specific use. So, depending on what you require – you should verify the specifications of the single board computer.
+
+If you think that you know about something that is better than the ones mentioned above, feel free to let us know in the comments below.
+
+--------------------------------------------------------------------------------
+
+via: https://itsfoss.com/raspberry-pi-alternatives/
+
+作者：[Ankush Das][a]
+选题：[lujun9972][b]
+译者：[译者ID](https://github.com/译者ID)
+校对：[校对者ID](https://github.com/校对者ID)
+
+本文由 [LCTT](https://github.com/LCTT/TranslateProject) 原创编译，[Linux中国](https://linux.cn/) 荣誉推出
+
+[a]: https://itsfoss.com/author/ankush/
+[b]: https://github.com/lujun9972
+[1]: https://itsfoss.com/best-linux-media-server/
+[2]: https://i2.wp.com/itsfoss.com/wp-content/uploads/2019/04/raspberry-pi-alternatives.png?resize=800%2C450&ssl=1
+[3]: https://itsfoss.com/affiliate-policy/
+[4]: https://i2.wp.com/itsfoss.com/wp-content/uploads/2019/04/omega-2-plus-e1555306748755-800x444.jpg?resize=800%2C444&ssl=1
+[5]: https://openwrt.org/
+[6]: https://amzn.to/2Xj8pkn
+[7]: https://onion.io/store/omega2p/
+[8]: https://i2.wp.com/itsfoss.com/wp-content/uploads/2019/04/Jetson-Nano-e1555306350976-800x590.jpg?resize=800%2C590&ssl=1
+[9]: https://developer.nvidia.com/embedded/buy/jetson-nano-devkit
+[10]: https://i0.wp.com/itsfoss.com/wp-content/uploads/2019/04/asus-tinker-board-s-e1555304945760-800x450.jpg?resize=800%2C450&ssl=1
+[11]: https://amzn.to/2XfkOFT
+[12]: https://en.wikipedia.org/wiki/MultiMediaCard
+[13]: https://www.asus.com/in/Single-Board-Computer/Tinker-Board-S/
+[14]: https://i2.wp.com/itsfoss.com/wp-content/uploads/2019/04/clockwork-pi-e1555305016242-800x506.jpg?resize=800%2C506&ssl=1
+[15]: https://itsfoss.com/gameshell-console/
+[16]: https://www.clockworkpi.com/product-page/cpi-v3-1
+[17]: https://i2.wp.com/itsfoss.com/wp-content/uploads/2019/04/arduino-mega-2560-e1555305257633.jpg?ssl=1
+[18]: https://store.arduino.cc/usa/mega-2560-r3
+[19]: https://amzn.to/2KCi041
+[20]: https://i0.wp.com/itsfoss.com/wp-content/uploads/2019/04/ROCK64_board-e1555306092845-800x440.jpg?resize=800%2C440&ssl=1
+[21]: https://www.pine64.org/?product=rock64-media-board-computer
+[22]: https://i1.wp.com/itsfoss.com/wp-content/uploads/2019/04/odroid-xu4.jpg?fit=800%2C354&ssl=1
+[23]: https://www.hardkernel.com/shop/odroid-xu4-special-price/
+[24]: https://i0.wp.com/itsfoss.com/wp-content/uploads/2019/04/PocketBeagle.jpg?fit=800%2C450&ssl=1
+[25]: https://beagleboard.org/p/products/pocketbeagle
+[26]: https://i1.wp.com/itsfoss.com/wp-content/uploads/2019/04/aml-libre.-e1555306237972-800x514.jpg?resize=800%2C514&ssl=1
+[27]: https://libre.computer/
+[28]: https://amzn.to/2DpG3xl
+[29]: https://libre.computer/products/boards/aml-s905x-cc/
+[30]: https://i2.wp.com/itsfoss.com/wp-content/uploads/2019/04/banana-pi-m6.jpg?fit=800%2C389&ssl=1
+[31]: http://www.banana-pi.org/m64.html
+[32]: https://i2.wp.com/itsfoss.com/wp-content/uploads/2019/04/orange-pi-zero.jpg?fit=800%2C693&ssl=1
+[33]: https://amzn.to/2IlI81g
+[34]: http://www.orangepi.org/orangepizero/index.html
+[35]: https://i0.wp.com/itsfoss.com/wp-content/uploads/2019/04/khadas-vim-2-e1555306505640-800x563.jpg?resize=800%2C563&ssl=1
+[36]: https://amzn.to/2UDvrFE


### PR DESCRIPTION
sources/tech/20190415 12 Single Board Computers- Alternative to Raspberry Pi.md