### PR TITLE
选题: 20190517 HPE to buy Cray, offer HPC as a service

### DIFF
--- a/sources/talk/20190517 HPE to buy Cray, offer HPC as a service.md
+++ b/sources/talk/20190517 HPE to buy Cray, offer HPC as a service.md
@@ -1,0 +1,68 @@
+[#]: collector: (lujun9972)
+[#]: translator: ( )
+[#]: reviewer: ( )
+[#]: publisher: ( )
+[#]: url: ( )
+[#]: subject: (HPE to buy Cray, offer HPC as a service)
+[#]: via: (https://www.networkworld.com/article/3396220/hpe-to-buy-cray-offer-hpc-as-a-service.html)
+[#]: author: (Tim Greene https://www.networkworld.com/author/Tim-Greene/)
+
+HPE to buy Cray, offer HPC as a service
+======
+High-performance computing offerings from HPE plus Cray could enable things like AI, ML, high-speed financial trading, creation digital twins for entire enterprise networks.
+![Cray Inc.][1]
+
+HPE has agreed to buy supercomputer-maker Cray for $1.3 billion, a deal that the companies say will bring their corporate customers high-performance computing as a service to help with analytics needed for artificial intelligence and machine learning, but also products supporting high-performance storage, compute and software.
+
+In addition to bringing HPC capabilities that can blend with and expand HPE’s current products, Cray brings with it customers in government and academia that might be interested in HPE’s existing portfolio as well.
+
+**[ Now read:[Who's developing quantum computers][2] ]**
+
+The companies say they expect to close the cash deal by the end of next April.
+
+The HPC-as-a-service would be offered through [HPE GreenLake][3], the company’s public-, private-, hybrid-cloud service. Such a service could address periodic enterprise need for fast computing that might otherwise be too expensive, says Tim Zimmerman, an analyst with Gartner.
+
+Businesses could use the service, for example, to create [digital twins][4] of their entire networks and use them to test new code to see how it will impact the network before deploying it live, Zimmerman says.
+
+Cray has HPC technology that HPE Labs might be exploring on its own, but that can be brought to market in a much quicker timeframe.
+
+HPE says that overall, buying cray give it technologies needed for massively data-intensive workloads such as AI and ML that is used for engineering services, transaction-based trading by financial firms, pharmaceutical research and academic studies into weather and genomes, for instance, Zimmerman says.
+
+As HPE puts it, Cray supercomputing platforms “have the ability to handle massive data sets, converged modelling, simulation, AI and analytics workloads.”
+
+Cray is working on [what it says will be the world’s fastest supercomputer][5] when it’s finished in 2021, cranking out 1.5 exaflops. The current fastest supercomputer is 143.5 petaflops. [Click [here][6] to see the current top 10 fastest supercomputers.]
+
+In general, HPE says it hopes to create a comprehensive line of products to support HPC infrastructure including “compute, high-performance storage, system interconnects, software and services.”
+
+Together, the talent in the two companies and their combined technologies should be able to increase innovation, HPE says.
+
+Earlier this month, HPE’s CEO Antonio Neri said in [an interview with _Network World_][7] that the company will be investing $4 billion over four years in a range of technology to boost “connectivity, security, and obviously cloud and analytics.” In laying out the company’s roadmap he made no specific mention of HPC.
+
+HPE net revenues last fiscal year were $30.9 billion. Cray’s total revenue was $456 million, with a gross profit of $130 million.
+
+The acquisition will pay $35 per share for Cray stock.
+
+Join the Network World communities on [Facebook][8] and [LinkedIn][9] to comment on topics that are top of mind.
+
+--------------------------------------------------------------------------------
+
+via: https://www.networkworld.com/article/3396220/hpe-to-buy-cray-offer-hpc-as-a-service.html
+
+作者：[Tim Greene][a]
+选题：[lujun9972][b]
+译者：[译者ID](https://github.com/译者ID)
+校对：[校对者ID](https://github.com/校对者ID)
+
+本文由 [LCTT](https://github.com/LCTT/TranslateProject) 原创编译，[Linux中国](https://linux.cn/) 荣誉推出
+
+[a]: https://www.networkworld.com/author/Tim-Greene/
+[b]: https://github.com/lujun9972
+[1]: https://images.idgesg.net/images/article/2018/06/the_cray_xc30_piz_daint_system_at_the_swiss_national_supercomputing_centre_via_cray_inc_3x2_978x652-100762113-large.jpg
+[2]: https://www.networkworld.com/article/3275385/who-s-developing-quantum-computers.html
+[3]: https://www.networkworld.com/article/3280996/hpe-adds-greenlake-hybrid-cloud-to-enterprise-service-offerings.html
+[4]: https://www.networkworld.com/article/3280225/what-is-digital-twin-technology-and-why-it-matters.html
+[5]: https://www.networkworld.com/article/3373539/doe-plans-worlds-fastest-supercomputer.html
+[6]: https://www.networkworld.com/article/3236875/embargo-10-of-the-worlds-fastest-supercomputers.html
+[7]: https://www.networkworld.com/article/3394879/hpe-s-ceo-lays-out-his-technology-vision.html
+[8]: https://www.facebook.com/NetworkWorld/
+[9]: https://www.linkedin.com/company/network-world


### PR DESCRIPTION
sources/talk/20190517 HPE to buy Cray, offer HPC as a service.md