### PR TITLE
选题: 20190523 Qualcomm loses case about its mobile-chip licensing fees

### DIFF
--- a/sources/talk/20190523 Qualcomm loses case about its mobile-chip licensing fees.md
+++ b/sources/talk/20190523 Qualcomm loses case about its mobile-chip licensing fees.md
@@ -1,0 +1,50 @@
+[#]: collector: (lujun9972)
+[#]: translator: ( )
+[#]: reviewer: ( )
+[#]: publisher: ( )
+[#]: url: ( )
+[#]: subject: (Qualcomm loses case about its mobile-chip licensing fees)
+[#]: via: (https://www.networkworld.com/article/3397052/qualcomm-loses-case-about-its-mobile-chip-licensing-fees.html)
+[#]: author: (Tim Greene https://www.networkworld.com/author/Tim-Greene/)
+
+Qualcomm loses case about its mobile-chip licensing fees
+======
+As 5G technology gears up, a federal court has ruled that Qualcomm’s ‘onerous’ fees for its mobile chips violate antitrust law.
+Chip maker Qualcomm has lost a round in federal court over how much it charges makers of wireless devices for its mobile chips.
+
+The company must lower its fees and submit to seven years of monitoring by the Federal Trade Commission, which brought the suit. Qualcomm says it will appeal.
+
+For more details about the suit and its impact on upcoming 5G deployments, watch this TECH(feed) video.
+
+**More about 5g networks:**
+
+  * [How enterprises can prep for 5G networks][1]
+  * [5G vs 4G: How speed, latency and apps support differ][2]
+  * [Private 5G networks are coming][3]
+  * [5G and 6G wireless have security issues][4]
+  * [How millimeter-wave wireless could help support 5G and IoT][5]
+
+
+
+Join the Network World communities on [Facebook][6] and [LinkedIn][7] to comment on topics that are top of mind.
+
+--------------------------------------------------------------------------------
+
+via: https://www.networkworld.com/article/3397052/qualcomm-loses-case-about-its-mobile-chip-licensing-fees.html
+
+作者：[Tim Greene][a]
+选题：[lujun9972][b]
+译者：[译者ID](https://github.com/译者ID)
+校对：[校对者ID](https://github.com/校对者ID)
+
+本文由 [LCTT](https://github.com/LCTT/TranslateProject) 原创编译，[Linux中国](https://linux.cn/) 荣誉推出
+
+[a]: https://www.networkworld.com/author/Tim-Greene/
+[b]: https://github.com/lujun9972
+[1]: https://www.networkworld.com/article/3306720/mobile-wireless/how-enterprises-can-prep-for-5g.html
+[2]: https://www.networkworld.com/article/3330603/mobile-wireless/5g-versus-4g-how-speed-latency-and-application-support-differ.html
+[3]: https://www.networkworld.com/article/3319176/mobile-wireless/private-5g-networks-are-coming.html
+[4]: https://www.networkworld.com/article/3315626/network-security/5g-and-6g-wireless-technologies-have-security-issues.html
+[5]: https://www.networkworld.com/article/3291323/mobile-wireless/millimeter-wave-wireless-could-help-support-5g-and-iot.html
+[6]: https://www.facebook.com/NetworkWorld/
+[7]: https://www.linkedin.com/company/network-world


### PR DESCRIPTION
sources/talk/20190523 Qualcomm loses case about its mobile-chip licensing fees.md