### PR TITLE
PUB:published/20211019 Dash to Dock is Finally Available for GNOME 40.md

### DIFF
--- a/published/20211019 Dash to Dock is Finally Available for GNOME 40.md
+++ b/published/20211019 Dash to Dock is Finally Available for GNOME 40.md
@@ -4,8 +4,8 @@
 [#]: collector: "lujun9972"
 [#]: translator: "wxy"
 [#]: reviewer: "wxy"
-[#]: publisher: " "
-[#]: url: " "
+[#]: publisher: "wxy"
+[#]: url: "https://linux.cn/article-13905-1.html"
 
 Dash to Dock 终于可以在 GNOME 40 上使用了
 ======


### PR DESCRIPTION
@wxy
https://linux.cn/article-13905-1.html