### PR TITLE
PUB:published/20211102 Fedora 35 Debuts With GNOME 41 and a New KDE Variant.md

### DIFF
--- a/published/20211102 Fedora 35 Debuts With GNOME 41 and a New KDE Variant.md
+++ b/published/20211102 Fedora 35 Debuts With GNOME 41 and a New KDE Variant.md
@@ -4,8 +4,8 @@
 [#]: collector: "lujun9972"
 [#]: translator: "wxy"
 [#]: reviewer: "wxy"
-[#]: publisher: " "
-[#]: url: " "
+[#]: publisher: "wxy"
+[#]: url: "https://linux.cn/article-13949-1.html"
 
 Fedora 35 登场：带来了 GNOME 41 和一个新的 KDE 变体
 ======


### PR DESCRIPTION
@wxy
https://linux.cn/article-13949-1.html