### PR TITLE
[申领原文][news]: 20220420 AlmaLinux 9.0 Beta Is Here, Ready to Replace to RHEL 9.md

### DIFF
--- a/sources/news/20220420 AlmaLinux 9.0 Beta Is Here, Ready to Replace to RHEL 9.md
+++ b/sources/news/20220420 AlmaLinux 9.0 Beta Is Here, Ready to Replace to RHEL 9.md
@@ -2,7 +2,7 @@
 [#]: via: "https://news.itsfoss.com/almalinux-9-0-beta-release/"
 [#]: author: "Jacob Crume https://news.itsfoss.com/author/jacob/"
 [#]: collector: "lujun9972"
-[#]: translator: " "
+[#]: translator: "lkxed"
 [#]: reviewer: " "
 [#]: publisher: " "
 [#]: url: " "


### PR DESCRIPTION
This article is being translated by lkxed.