### PR TITLE
[手动选题][news]: 20220502 Ubuntu’s Unity Desktop Still Lives- Version 7.6 is Available for Testing After 6 Years.md

### DIFF
--- a/sources/news/20220502 Ubuntu’s Unity Desktop Still Lives- Version 7.6 is Available for Testing After 6 Years.md
+++ b/sources/news/20220502 Ubuntu’s Unity Desktop Still Lives- Version 7.6 is Available for Testing After 6 Years.md
@@ -1,0 +1,84 @@
+[#]: subject: "Ubuntu’s Unity Desktop Still Lives: Version 7.6 is Available for Testing After 6 Years"
+[#]: via: "https://news.itsfoss.com/unity-7-6-testing/"
+[#]: author: "Ankush Das https://news.itsfoss.com/author/ankush/"
+[#]: collector: "lkxed"
+[#]: translator: " "
+[#]: reviewer: " "
+[#]: publisher: " "
+[#]: url: " "
+
+Ubuntu’s Unity Desktop Still Lives: Version 7.6 is Available for Testing After 6 Years
+======
+While Canonical no longer maintains it, Ubuntu Unity’s developer has taken up the task with a major upgrade (currently for testing).
+
+![unity 7.6][1]
+
+Before you get too excited, you should know that Canonical is not coming back to maintain Unity desktop.
+
+Thanks to the developer of the Ubuntu Unity distribution (*Rudra Saraswat*), we get to see an update to the Unity desktop environment after six long years.
+
+In case you did not know, [Ubuntu Unity][2] is a community project that utilizes the Unity interface instead of GNOME. So, yes, if you wanted to use Ubuntu 22.04 LTS with Unity desktop, [Ubuntu Unity][2] is your friend.
+
+Initially, it simply offered the Unity experience with a few tweaks. But, now, **Unity 7.6** looks to be getting some improvements and visual changes to the interface.
+
+Here’s what you should know about it:
+
+### Unity 7.6: What’s New?
+
+**Note**: Unity 7.6 is out for public testing and should not be a replacement for other desktop environments.
+
+It is not just about the user-facing side, but there have been development efforts to help contributors conveniently help with Unity7’s development.
+
+Some refinements include:
+
+#### User Interface Changes
+
+![unity desktop][3]
+
+The dash launcher (app launcher) and HUD have been redesigned for a modern/slick look.
+
+Overall, the design is now much flatter but retains the good-old system-wide blur effect. The dock’s menu and tooltips also received some refreshed modern look.
+
+There are some subtle visual improvements like ‘Empty Trash’ button in the dock using Nemo instead of Nautilus and fixing the app info and ratings in dash preview.
+
+#### Performance Improvements
+
+![unity desktop][4]
+
+The RAM usage in Unity7 is lower with the latest update. And, you can notice the RAM usage with Ubuntu Unity 22.04 is significantly lower to about 700-800 MB.
+
+Furthermore, the low graphics mode works much better now, making the dash faster than ever.
+
+#### Other Changes
+
+The Unity7’s shell source code has been migrated entirely to [GitLab][5]. The standalone testing Unity7 launcher has been fixed, and the buggy tests have been disabled, improving the build time (making it much shorter).
+
+The release notes say that these changes should help Unity7 contributors.
+
+### Testing Unity 7.6
+
+You can follow the instructions mentioned in the [official testing announcement][6] to compile it and try it for yourself. You can also head to its official website to explore more.
+
+In either case, you can wait for an update to Ubuntu Unity 22.04, if you would rather not add the testing PPA yet.
+
+*What do you think about this refreshment to the Unity desktop environment? Do you like it? Let me know your thoughts in the comments.*
+
+--------------------------------------------------------------------------------
+
+via: https://news.itsfoss.com/unity-7-6-testing/
+
+作者：[Ankush Das][a]
+选题：[lkxed][b]
+译者：[译者ID](https://github.com/译者ID)
+校对：[校对者ID](https://github.com/校对者ID)
+
+本文由 [LCTT](https://github.com/LCTT/TranslateProject) 原创编译，[Linux中国](https://linux.cn/) 荣誉推出
+
+[a]: https://news.itsfoss.com/author/ankush/
+[b]: https://github.com/lkxed
+[1]: https://news.itsfoss.com/wp-content/uploads/2022/05/unity-7-6-release.jpg
+[2]: https://ubuntuunity.org/
+[3]: https://news.itsfoss.com/wp-content/uploads/2022/05/unity-7-6.jpg
+[4]: https://news.itsfoss.com/wp-content/uploads/2022/05/neofetch-unity-7-6.png
+[5]: https://gitlab.com/ubuntu-unity
+[6]: https://unity.ubuntuunity.org/blog/unity-7.6/


### PR DESCRIPTION
This article is collected by lkxed.