### PR TITLE
[申领原文][news]: 20220526 DeepMind-s Open Source MuJoCo Is Available On GitHub.md

### DIFF
--- a/sources/news/20220526 DeepMind-s Open Source MuJoCo Is Available On GitHub.md
+++ b/sources/news/20220526 DeepMind-s Open Source MuJoCo Is Available On GitHub.md
@@ -2,7 +2,7 @@
 [#]: via: "https://www.opensourceforu.com/2022/05/deepminds-open-source-mujoco-is-available-on-github/"
 [#]: author: "Laveesh Kocher https://www.opensourceforu.com/author/laveesh-kocher/"
 [#]: collector: "lkxed"
-[#]: translator: " "
+[#]: translator: "lkxed"
 [#]: reviewer: " "
 [#]: publisher: " "
 [#]: url: " "


### PR DESCRIPTION
This article is being translated by lkxed.