### PR TITLE
[手动选题][news]: 20220609 Atom Text Editor Will Officially Be Terminated Later This Year.md

### DIFF
--- a/sources/news/20220609 Atom Text Editor Will Officially Be Terminated Later This Year.md
+++ b/sources/news/20220609 Atom Text Editor Will Officially Be Terminated Later This Year.md
@@ -1,0 +1,41 @@
+[#]: subject: "Atom Text Editor Will Officially Be Terminated Later This Year"
+[#]: via: "https://www.opensourceforu.com/2022/06/atom-text-editor-will-officially-be-terminated-later-this-year/"
+[#]: author: "Laveesh Kocher https://www.opensourceforu.com/author/laveesh-kocher/"
+[#]: collector: "lkxed"
+[#]: translator: " "
+[#]: reviewer: " "
+[#]: publisher: " "
+[#]: url: " "
+
+Atom Text Editor Will Officially Be Terminated Later This Year
+======
+![github-cover][1]
+
+On December 15, Microsoft’s GitHub will shut down Atom, its open source text editor that inspired and influenced widely used commercial apps such as Microsoft Visual Studio Code, Slack, and GitHub Desktop. The social code company stated that it is doing so to focus on cloud-based software.
+
+GitHub Codespaces is a cloud-hosted development environment with Visual Studio Code integration. When Microsoft acquired Github in June 2018, Nat Friedman, the CEO at the time, reassured the GitHub community that Atom was still alive and well.
+
+Atom has come to a halt after four years of progress. Apart from maintenance and security updates, the project hasn’t seen significant feature development in several years, according to GitHub. Community involvement has declined during this time, and the business of locally installed software now appears less appealing than the potential recurring revenue, vendor lock-in, and information gathering enabled by cloud-based apps.
+
+The Atom shell – a separate component for integrating with Chromium, Node.js, and native APIs – was renamed Electron (a cross-platform app framework based on web tech) in 2015, and Microsoft began working with GitHub on Atom and Electron and what would become Visual Studio Code.
+
+That relationship has now followed the famous Microsoft model of embrace, extend, and extinguish, though Atom’s demise appears to be more like pushing dead weight out of a cloud-bound balloon than a strategically advantageous hit.
+
+Atom’s influence should be felt through the Electron framework. Electron.js is still the foundation for apps such as Discord, Skype, Slack, Trello, and Visual Studio Code, among others. However, technology evolves. Microsoft previously stated that it intends to abandon Electron in Teams. Other cross-platform frameworks, such as Flutter, Tauri, and Microsoft’s recently announced.NET Multi-platform App UI (.NET MAUI), may gain traction as well.
+
+Nonetheless, Atom is expected to operate past its December 15, 2022 decommissioning date. GitHub intends to archive the Atom repository, but the code is open source and available to anyone who wants to champion the project.
+
+--------------------------------------------------------------------------------
+
+via: https://www.opensourceforu.com/2022/06/atom-text-editor-will-officially-be-terminated-later-this-year/
+
+作者：[Laveesh Kocher][a]
+选题：[lkxed][b]
+译者：[译者ID](https://github.com/译者ID)
+校对：[校对者ID](https://github.com/校对者ID)
+
+本文由 [LCTT](https://github.com/LCTT/TranslateProject) 原创编译，[Linux中国](https://linux.cn/) 荣誉推出
+
+[a]: https://www.opensourceforu.com/author/laveesh-kocher/
+[b]: https://github.com/lkxed
+[1]: https://www.opensourceforu.com/wp-content/uploads/2022/06/github-cover-e1654769639273.jpg


### PR DESCRIPTION
This article is collected by lkxed.