### PR TITLE
[手动选题][news]: 20220828 Debian Linux is Replacing Google With DuckDuckGo as the Default Search Engine for Chromium.md

### DIFF
--- a/sources/news/20220828 Debian Linux is Replacing Google With DuckDuckGo as the Default Search Engine for Chromium.md
+++ b/sources/news/20220828 Debian Linux is Replacing Google With DuckDuckGo as the Default Search Engine for Chromium.md
@@ -1,0 +1,68 @@
+[#]: subject: "Debian Linux is Replacing Google With DuckDuckGo as the Default Search Engine for Chromium"
+[#]: via: "https://news.itsfoss.com/debian-duckduckgo-default-chromium/"
+[#]: author: "Anuj Sharma https://news.itsfoss.com/author/anuj/"
+[#]: collector: "lkxed"
+[#]: translator: " "
+[#]: reviewer: " "
+[#]: publisher: " "
+[#]: url: " "
+
+Debian Linux is Replacing Google With DuckDuckGo as the Default Search Engine for Chromium
+======
+Soon, the Chromium browser in Debian will have DuckDuckGo as the default search engine.
+
+![Debian Linux is Replacing Google With DuckDuckGo as the Default Search Engine for Chromium][1]
+
+[DuckDuckGo][2] is a private search engine that doesn't track its user the same way Google does. Its focus on privacy is why many Linux users prefer using it over Google.
+
+While Firefox is still the default web browser in Debian, you can find the Chromium browser in the repositories.
+
+Chromium is the open source project upon which Google has built its Chrome web browser. It is also preferred by many Linux users as it provides almost the same features as Google Chrome.
+
+Earlier, Chromium used Google as the default search engine in Debian. However, Debian is going to use DuckDuckGo as the default search engine for Chromium.
+
+### DuckDuckGo over Google because privacy
+
+It all started when bug report [#956012][3] was filed in April 2020, stating to use DuckDuckGo as the default search engine for the Chromium package.
+
+You can see the decision was not taken in any hurry, as the maintainers took more than two years to close the bug report.
+
+The reason for the change goes as stated in the official package update [announcement][4].
+
+The change is applicable for Chromium version 104 or later as per the announcement. If you are on Debian Stable, it may take some time for the package to come to stable repos.
+
+However, people running Debian testing and unstable can see the change appear in their installs right now by updating their systems.
+
+Debian versions older than Stable may not see this update.
+
+[Hidden Features! 25 Fun Things You Can Do With DuckDuckGo Search Engine - It’s FOSS][5]
+
+### Conclusion
+
+Google search engine is known to track users and thus the privacy cautious users should find this change positive.
+
+I know some hardcore privacy enthusiasts question if DuckDuckGo is really as private as it claims. If that's the case, check out some other alternative search engines in this list 👇
+
+[10 Best Privacy Oriented Search Engines To Google in 2021][6]
+
+I believe this is positive news. What do you think?
+
+--------------------------------------------------------------------------------
+
+via: https://news.itsfoss.com/debian-duckduckgo-default-chromium/
+
+作者：[Anuj Sharma][a]
+选题：[lkxed][b]
+译者：[译者ID](https://github.com/译者ID)
+校对：[校对者ID](https://github.com/校对者ID)
+
+本文由 [LCTT](https://github.com/LCTT/TranslateProject) 原创编译，[Linux中国](https://linux.cn/) 荣誉推出
+
+[a]: https://news.itsfoss.com/author/anuj/
+[b]: https://github.com/lkxed
+[1]: https://news.itsfoss.com/content/images/size/w1200/2022/08/debian-replaces-google-withddg.png
+[2]: https://duckduckgo.com/
+[3]: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=956012
+[4]: https://www.mail-archive.com/debian-devel-changes@lists.debian.org/msg760508.html
+[5]: https://itsfoss.com/duckduckgo-easter-eggs/
+[6]: https://itsfoss.com/privacy-search-engines/


### PR DESCRIPTION
This article is collected by lkxed.