### PR TITLE
[手动选题][news]: 20220902 Microsoft Decides to Drop the Linux App for Teams to Replace it as a Progressive Web App Instead.md

### DIFF
--- a/sources/news/20220902 Microsoft Decides to Drop the Linux App for Teams to Replace it as a Progressive Web App Instead.md
+++ b/sources/news/20220902 Microsoft Decides to Drop the Linux App for Teams to Replace it as a Progressive Web App Instead.md
@@ -1,0 +1,67 @@
+[#]: subject: "Microsoft Decides to Drop the Linux App for Teams to Replace it as a Progressive Web App Instead"
+[#]: via: "https://news.itsfoss.com/microsoft-linux-app-retire/"
+[#]: author: "Ankush Das https://news.itsfoss.com/author/ankush/"
+[#]: collector: "lkxed"
+[#]: translator: " "
+[#]: reviewer: " "
+[#]: publisher: " "
+[#]: url: " "
+
+Microsoft Decides to Drop the Linux App for Teams to Replace it as a Progressive Web App Instead
+======
+Microsoft will no longer offer a Linux app for Teams. Here's how you can access Microsoft Teams on Linux moving forward.
+
+![Microsoft Decides to Drop the Linux App for Teams to Replace it as a Progressive Web App Instead][1]
+
+**Microsoft loves Linux…**💔
+
+If you remember Microsoft marketing this, you know this is not entirely true when reading this news.
+
+Microsoft introduced the Linux app for Teams back in 2019 as a public preview. Now, within three years of its existence, they decided to retire the Linux client in **early December** 2022.
+
+At the time of publishing this, there are no official announcements to address this. However, this news was potentially spotted by an administrator using Microsoft Teams. Probably as one of the internal admin notices (via [Hacker News][2]).
+
+The notice mentions:
+
+### Progressive Web App (PWA) to Replace the Linux App
+
+![microsoft teams linux app][3]
+
+Microsoft says that moving on, they will be offering a Teams progressive web app (PWA) on Linux.
+
+The PWA will support Background blur, custom backgrounds, reactions, and a couple other desktop app-like features. So, for some users, this is good news.
+
+It is not clear when the PWA will be made available, as they only mention that you can expect it in the coming months.
+
+**Unfortunately**, Mozilla Firefox (one of the best browsers for Linux) does not offer support for PWA.
+
+So, as per the official information, you can expect the PWA to work on [Edge][4], and [Chrome browsers on Linux][5]:
+
+### What Can You Do Now?
+
+Honestly, Microsoft Teams app on Linux was not a great experience.
+
+Therefore, you should start using the web app or wait for the PWA experience. Of course, it may not be convenient to use Microsoft Edge or Chrome browsers if you use its alternatives. But, that's what it is.
+
+You can also try some unofficial Linux clients, but I'm not certain how good that would work.
+
+💬 *What do you think about Microsoft retiring its official Linux app to favor a PWA or its web experience? Share your thoughts in the comments below.*
+
+--------------------------------------------------------------------------------
+
+via: https://news.itsfoss.com/microsoft-linux-app-retire/
+
+作者：[Ankush Das][a]
+选题：[lkxed][b]
+译者：[译者ID](https://github.com/译者ID)
+校对：[校对者ID](https://github.com/校对者ID)
+
+本文由 [LCTT](https://github.com/LCTT/TranslateProject) 原创编译，[Linux中国](https://linux.cn/) 荣誉推出
+
+[a]: https://news.itsfoss.com/author/ankush/
+[b]: https://github.com/lkxed
+[1]: https://news.itsfoss.com/content/images/size/w1200/2022/09/ms-dropping-teams-for-linux.png
+[2]: https://news.ycombinator.com/item?id=32678839
+[3]: https://news.itsfoss.com/content/images/2022/09/teams-linux.jpg
+[4]: https://itsfoss.com/microsoft-edge-linux/
+[5]: https://itsfoss.com/install-chrome-ubuntu/


### PR DESCRIPTION
This article is collected by lkxed.