### PR TITLE
[手动选题][news]: 20221018-⭐️-Ardour-7-0-Release-Marks-the-end-of-32-bit-builds--Adds-Clip-Launching-and-Apple-Silicon-Support.md

### DIFF
--- a/sources/news/20221018-⭐️-Ardour-7-0-Release-Marks-the-end-of-32-bit-builds--Adds-Clip-Launching-and-Apple-Silicon-Support.md
+++ b/sources/news/20221018-⭐️-Ardour-7-0-Release-Marks-the-end-of-32-bit-builds--Adds-Clip-Launching-and-Apple-Silicon-Support.md
@@ -1,0 +1,100 @@
+[#]: subject: "Ardour 7.0 Release Marks the end of 32-bit builds; Adds Clip Launching and Apple Silicon Support"
+[#]: via: "https://news.itsfoss.com/ardour-7-0-release/"
+[#]: author: "Sourav Rudra https://news.itsfoss.com/author/sourav/"
+[#]: collector: "lkxed"
+[#]: translator: " "
+[#]: reviewer: " "
+[#]: publisher: " "
+[#]: url: " "
+
+Ardour 7.0 Release Marks the end of 32-bit builds; Adds Clip Launching and Apple Silicon Support
+======
+
+Ardour 7.0 is a major upgrade with much-needed improvements.
+
+![Ardour 7.0 Release Marks the end of 32-bit builds; Adds Clip Launching and Apple Silicon Support][1]
+
+[Ardour][2] is a popular open-source digital audio workstation software that audio professionals use.
+
+Ardour 7.0 has been in development for a little more than a year since the release of 6.9 and has come a long way since Ardour 5.0.
+
+Let's take a look at the highlights of this release.
+
+### 🆕 Ardour 7.0: What's New?
+
+![ardour 7.0][3]
+
+This release introduces a variety of changes and feature additions, some of the highlights are:
+
+- **Discontinuation of 32-bit Builds.**
+- **Clip Launching feature (similar to what other DAWs provide).**
+- **Support for Apple Silicon.**
+- **Integration of Loop Library.**
+- **Audio sample library support by Freesound.**
+
+#### Clip Launching
+
+![ardour 7.0 clip launching][4]
+
+Similar to many mainstream DAWs like Ableton Live, Ardour now has support for clip launching.
+
+Users can now play/stop audio clips and adjust the timing to fit the tempo map of a session. Pretty useful for live performances.
+
+#### Loop Library
+
+![ardour 7.0 loop library][5]
+
+In addition to Clip Launching, users can also take advantage of a vast collection of loops sourced from a few hand-picked creators of [looperman][6].
+
+Users can choose from any of the royalty-free loops, with more to be added in the near future.
+
+#### End of 32-bit Builds
+
+There won't be any further 32-bit builds of Ardour, only a few will remain available on the nightly build channels for now.
+
+You may want to look around at some of the DAWs available for Linux to see what else might offer a 32-bit build.
+
+#### Sound Samples Available by Freesound
+
+![ardour 7.0 freesound integration][7]
+
+Another feature that complements the Loop Library is the integration with [Freesound][8].
+
+With this, users can make use of over 600,000 samples of audio. To do this, users must have a Freesound account linked to their Ardour installation.
+
+#### 🛠️ Other Changes
+
+Other notable changes include:
+
+- **New Themes.**
+- **Ripple Editing Modes.**
+- **Mixer Scenes.**
+- **Improvements to MIDI Editing.**
+- **Support for I/O Plugins.**
+
+You can go through the official [release notes][9] for more details of the release.
+
+_💬 Are you going to try out Ardour 7.0? Satisfied with the DAW you currently use?_
+
+--------------------------------------------------------------------------------
+
+via: https://news.itsfoss.com/ardour-7-0-release/
+
+作者：[Sourav Rudra][a]
+选题：[lkxed][b]
+译者：[译者ID](https://github.com/译者ID)
+校对：[校对者ID](https://github.com/校对者ID)
+
+本文由 [LCTT](https://github.com/LCTT/TranslateProject) 原创编译，[Linux中国](https://linux.cn/) 荣誉推出
+
+[a]: https://news.itsfoss.com/author/sourav/
+[b]: https://github.com/lkxed
+[1]: https://news.itsfoss.com/content/images/size/w1200/2022/10/ardour-7-0-release.jpg
+[2]: https://ardour.org/
+[3]: https://news.itsfoss.com/content/images/2022/10/Ardour_7.0.png
+[4]: https://news.itsfoss.com/content/images/2022/10/Ardour_7.0_Clip_Launching.png
+[5]: https://news.itsfoss.com/content/images/2022/10/Ardour_7.0_Loop_Library.png
+[6]: https://www.looperman.com/
+[7]: https://news.itsfoss.com/content/images/2022/10/Ardour_7.0_Freesound_Integration.png
+[8]: https://freesound.org/
+[9]: https://ardour.org/whatsnew.html


### PR DESCRIPTION
This article is collected by lkxed.