### PR TITLE
[手动选题][news]: 20221101.12 ⭐️ OpenSSL 3.0.7 Fixes Two High-CVEs with Buffer Overflow.md

### DIFF
--- a/sources/news/20221101.12 ⭐️ OpenSSL 3.0.7 Fixes Two High-CVEs with Buffer Overflow.md
+++ b/sources/news/20221101.12 ⭐️ OpenSSL 3.0.7 Fixes Two High-CVEs with Buffer Overflow.md
@@ -1,0 +1,61 @@
+[#]: subject: "OpenSSL 3.0.7 Fixes Two High-CVEs with Buffer Overflow"
+[#]: via: "https://debugpointnews.com/openssl-3-0-7/"
+[#]: author: "arindam https://debugpointnews.com/author/dpicubegmail-com/"
+[#]: collector: "lkxed"
+[#]: translator: " "
+[#]: reviewer: " "
+[#]: publisher: " "
+[#]: url: " "
+
+OpenSSL 3.0.7 Fixes Two High-CVEs with Buffer Overflow
+======
+
+![][1]
+
+**OpenSSL 3.0.7, released today, fixes two critical security issues that have caused panic since last week.**
+
+### OpenSSL 3.0.7 release
+
+The highly anticipated OpenSSL 3.0.7 is now released, fixing two high-severity CVEs. All the major Linux distributions across desktops and, most importantly, server admins have been waiting for this fix since it was reported last week by the OpenSSL team. Due to the criticality of this package, some distro releases got delayed (such as [Fedora 37][2]), and probably some patching activities across the industry.
+
+Both the high severity fixes are due to buffer overrun, which impacts the entire OpenSSL 3.0.0 series (i.e. from 3.0.0 to 3.0.6). Alarming, it may sound, but these two vulnerabilities have been out in the wild for almost a year since the 3.0.0 release in 2021.
+
+The first [CVE-2022-3786][3] triggers when a malicious email address with arbitrary payload with character “.” (decimal 46). The second vulnerability, CVE-2022-3602, also deals with another payload with the same email address in name constraints, checking for X.509 certificates.
+
+### Distro Patching
+
+As of publishing this, major distros (Debian, Ubuntu, Fedora, RedHat) are yet to update their OpenSSL package with version 3.0.7.
+
+So, as soon as it arrives, make sure you update your desktops and servers immediately. This is critical for those who deal with TLS-based authentication over remote connections to various servers.
+
+Keep a watch on the below pages for updated packages for major Linux distributions.
+
+- [Ubuntu][4] (Jammy)
+- [Fedora][5]
+- [Debian][6] (Bookworm, testing)
+
+Arch Linux folks are superfast, it seems. It’s already in the[staging repo][7]within two hours of the release!
+
+Via [OpenSSL release notes][8].
+
+--------------------------------------------------------------------------------
+
+via: https://debugpointnews.com/openssl-3-0-7/
+
+作者：[arindam][a]
+选题：[lkxed][b]
+译者：[译者ID](https://github.com/译者ID)
+校对：[校对者ID](https://github.com/校对者ID)
+
+本文由 [LCTT](https://github.com/LCTT/TranslateProject) 原创编译，[Linux中国](https://linux.cn/) 荣誉推出
+
+[a]: https://debugpointnews.com/author/dpicubegmail-com/
+[b]: https://github.com/lkxed
+[1]: https://debugpointnews.com/wp-content/uploads/2022/11/openssl-head-816x459.jpg
+[2]: https://debugpointnews.com/fedora-37-release-delay/
+[3]: https://www.openssl.org/news/vulnerabilities.html#CVE-2022-3602
+[4]: https://packages.ubuntu.com/jammy/openssl
+[5]: https://packages.fedoraproject.org/pkgs/openssl/openssl/
+[6]: https://packages.debian.org/bookworm/openssl
+[7]: https://archlinux.org/packages/?sort=&q=openssl&maintainer=&flagged=
+[8]: https://mta.openssl.org/pipermail/openssl-announce/2022-November/000241.html


### PR DESCRIPTION
This article is collected by lkxed.