### PR TITLE
[手动选题][tech]: 20221118.0 ⭐️⭐️ Fixing “Key is stored in legacy trusted.gpg keyring” Issue in Ubuntu.md

### DIFF
--- a/sources/tech/20221118.0 ⭐️⭐️ Fixing “Key is stored in legacy trusted.gpg keyring” Issue in Ubuntu.md
+++ b/sources/tech/20221118.0 ⭐️⭐️ Fixing “Key is stored in legacy trusted.gpg keyring” Issue in Ubuntu.md
@@ -1,0 +1,144 @@
+[#]: subject: "Fixing “Key is stored in legacy trusted.gpg keyring” Issue in Ubuntu"
+[#]: via: "https://itsfoss.com/authenticator/"
+[#]: author: "Abhishek Prakash https://itsfoss.com/"
+[#]: collector: "lkxed"
+[#]: translator: " "
+[#]: reviewer: " "
+[#]: publisher: " "
+[#]: url: " "
+
+Fixing “Key is stored in legacy trusted.gpg keyring” Issue in Ubuntu
+======
+
+If you use a PPA or add an external repository in Ubuntu 22.04 and later versions, chances are that you will see a message like this:
+
+```
+W: https://packagecloud.io/slacktechnologies/slack/debian/dists/jessie/InRelease: Key is stored in legacy trusted.gpg keyring (/etc/apt/trusted.gpg), see the DEPRECATION section in apt-key(8) for details.
+```
+
+![ubuntu key is stored legacy][1]
+
+First thing first. It is not an error, it is a warning message. A warning does not stop the procedure. You can continue upgrading your system even if you see this warning message during an update.
+
+If you don’t like seeing the warning message, you can take some manual steps to get rid of it.
+
+There are two ways; the proper way and the quick and dirty way. Read both methods and see which one you feel comfortable with.
+
+### Method 1: Import the key [Proper but complicated way]
+
+First, list all the GPG keys added to your system.
+
+```
+sudo apt-key list
+```
+
+This will show a huge list of keys stored in your system. What you have to do here is to look for the keys associated with the warning message.
+
+```
+[email protected]:~$ sudo apt-key list
+[sudo] password for abhishek: 
+Warning: apt-key is deprecated. Manage keyring files in trusted.gpg.d instead (see apt-key(8)).
+/etc/apt/trusted.gpg
+--------------------
+pub   rsa4096 2014-01-13 [SCEA] [expired: 2019-01-12]
+      418A 7F2F B0E1 E6E7 EABF  6FE8 C2E7 3424 D590 97AB
+uid           [ expired] packagecloud ops (production key) <[email protected]>
+
+pub   rsa4096 2016-02-18 [SCEA]
+      DB08 5A08 CA13 B8AC B917  E0F6 D938 EC0D 0386 51BD
+uid           [ unknown] https://packagecloud.io/slacktechnologies/slack (https://packagecloud.io/docs#gpg_signing) <[email protected]>
+sub   rsa4096 2016-02-18 [SEA]
+
+/etc/apt/trusted.gpg.d/audio-recorder-ubuntu-ppa.gpg
+----------------------------------------------------
+pub   rsa4096 2015-08-30 [SC]
+      42EF 41ED 9813 B713 D4F1  F06D 5CF1 2638 ACF9 669F
+uid           [ unknown] Launchpad PPA for Team audio-recorder
+
+/etc/apt/trusted.gpg.d/danielrichter2007-ubuntu-grub-customizer.gpg
+-------------------------------------------------------------------
+pub   rsa1024 2010-10-08 [SC]
+      59DA D276 B942 642B 1BBD  0EAC A8AA 1FAA 3F05 5C03
+```
+
+How do you do that? Read the message carefully. 
+
+```
+W: https://packagecloud.io/slacktechnologies/slack/debian/dists/jessie/InRelease: Key is stored in legacy
+```
+
+In my case, the repository has keywords like packagecloud, slacktechnologies. It is shown at the top of the apt-key list output. You may have to scroll a bit in your case.
+
+In this rare case, the external repository added by Slack, has two GPG keys. One of them is expired and I’ll ignore it. You may not have such a situation.
+
+You should the last 8 characters (excluding the space) under the line after pub.
+
+```
+/etc/apt/trusted.gpg
+--------------------
+pub   rsa4096 2014-01-13 [SCEA] [expired: 2019-01-12]
+      418A 7F2F B0E1 E6E7 EABF  6FE8 C2E7 3424 D590 97AB
+uid           [ expired] packagecloud ops (production key) <[email protected]>
+
+pub   rsa4096 2016-02-18 [SCEA]
+      DB08 5A08 CA13 B8AC B917  E0F6 D938 EC0D 0386 51BD
+uid           [ unknown] https://packagecloud.io/slacktechnologies/slack (https://packagecloud.io/docs#gpg_signing) <[email protected]>
+```
+
+So from the line “DB08 5A08 CA13 B8AC B917 E0F6 D938 EC0D 0386 51BD”, I’ll take the last 8 characters “0386 51BD”, remove the space and then use it to import the GPG key in its dedicated file under the /etc/apt/trusted.gpg.d directory:
+
+```
+sudo apt-key export 038651BD | sudo gpg --dearmour -o /etc/apt/trusted.gpg.d/slack.gpg
+```
+
+I created a new file slack.gpg here, in case you didn’t notice it. I named it slack.gpg because it is associated with Slack application I installed earlier. The filename does not matter but it’s good for identification.
+
+If the command runs successfully, you won’t see any message. You can verify that by checking if the newly created gpg file exists or not.
+
+![import gpg key to trusted ubuntu][2]
+
+Run the update again and now you should not see the warning message anymore.
+
+### Method 2: Copy to the trusted.gpd.d directory [Quick and dirty way]
+
+If you don’t feel comfortable doing all the above stuff manually, well, you can ignore the warning message. I mean, ignoring it is always an option.
+
+Another option is to copy the /etc/apt/trusted.gpg file to /etc/apt/trusted.gpg.d directory. After all, Ubuntu only complains that it needs the GPG keys in /etc/apt/trusted.gpg.d directory.
+
+You’ll still have to use the terminal. Open it and use the following command:
+
+```
+sudo cp /etc/apt/trusted.gpg /etc/apt/trusted.gpg.d
+```
+
+Now, if you run the update, you won’t see the “Key is stored in legacy trusted.gpg keyring” warning message anymore.
+
+![quick dirty way to fix apt key stored legacy][3]
+
+### Conclusion
+
+I have written a detailed article on [apt-key deprecation][4]. Apparently, that article had some readers confused and hence I wrote this one to give them direct steps for getting rid of the message.
+
+As I said before, it is a warning message and can be ignored for now. The onus to ‘fix’ this issue lies on the external software developers and Ubuntu developers. The external software developers should make sure that their GPG keys are no longer added in the /etc/apt/trusted.gpg file. 
+
+The end users should not take the pain for their laziness.
+
+So, which method did you use to get rid of the ‘key is stored in legacy’ warning message? The first one or the second one?
+
+--------------------------------------------------------------------------------
+
+via: https://itsfoss.com/authenticator/
+
+作者：[Abhishek Prakash][a]
+选题：[lkxed][b]
+译者：[译者ID](https://github.com/译者ID)
+校对：[校对者ID](https://github.com/校对者ID)
+
+本文由 [LCTT](https://github.com/LCTT/TranslateProject) 原创编译，[Linux中国](https://linux.cn/) 荣誉推出
+
+[a]: https://itsfoss.com/
+[b]: https://github.com/lkxed
+[1]: https://itsfoss.com/wp-content/uploads/2022/11/ubuntu-key-is-stored-legacy.png
+[2]: https://itsfoss.com/wp-content/uploads/2022/11/import-gpg-key-to-trusted-ubuntu.png
+[3]: https://itsfoss.com/wp-content/uploads/2022/11/quick-dirty-way-to-fix-apt-key-stored-legacy.png
+[4]: https://itsfoss.com/apt-key-deprecated/


### PR DESCRIPTION
This article is collected by lkxed.