### PR TITLE
[手动选题][news]: 20221206.1 ⭐️ Gnoppix Linux 22.12 is out with GNOME 43, Kernel 6.0, + More.md

### DIFF
--- a/sources/news/20221206.1 ⭐️ Gnoppix Linux 22.12 is out with GNOME 43, Kernel 6.0, + More.md
+++ b/sources/news/20221206.1 ⭐️ Gnoppix Linux 22.12 is out with GNOME 43, Kernel 6.0, + More.md
@@ -1,0 +1,81 @@
+[#]: subject: "Gnoppix Linux 22.12 is out with GNOME 43, Kernel 6.0, + More"
+[#]: via: "https://debugpointnews.com/gnoppix-22-12-release/"
+[#]: author: "arindam https://debugpointnews.com/author/dpicubegmail-com/"
+[#]: collector: "lkxed"
+[#]: translator: " "
+[#]: reviewer: " "
+[#]: publisher: " "
+[#]: url: " "
+
+Gnoppix Linux 22.12 is out with GNOME 43, Kernel 6.0, + More
+======
+
+![][1]
+
+**Kali-linux-based rolling Linux distro Gnoppix 22.12 brings GNOME 43, Linux Kernel 6.0 and new upgrades.**
+
+![Gnoppix 22.12 desktop][2]
+
+The successor of the legacy live-cd Knoppix project, [Gnoppix][3] Linux is designed specifically for use in penetration testing and reverse engineering. It is optimized for web application security and for protecting digital rights. In addition to its focus on security, Gnoppix can also be used as a regular desktop operating system. It is a rolling release that receives frequent updates and new features.
+
+At its core, it is based on Kali Linux and Debian-rolling for some parts. And brings a GNOME desktop in contrast with Xfce for Kali Linux.
+
+### Gnoppix Linux 22.12: What’s New
+
+The current major release is Gnoppix 22, which is an ongoing point release, and recently its team released Gnoppix 22.12 with the following updates.
+
+Firstly the Kernel version is bumped up to Linux Kernel 6.0 and the latest [GNOME 43.2 desktop][4]. If you want to use this distro as a desktop, then some good news for you on the default application list.
+
+Gnoppix 22.12 added the GIMP image editor, Deluge & Transmission, clapper music player and gnome-firmware updater.
+
+Furthermore, all the native GNOME packages are bumped up to the 43.2 version while the team started working on 44, which is due on February 2023.
+
+![GNOME 43.2 workspace view][5]
+
+Other key components and apps include the following:
+
+- LibreOffice 7.4.2.3
+- Linux mainline Kernel 6.0.7
+- OpenJDK 11
+- pipewire 0.3.60
+- Firefox ESR 102
+- Python 3.10
+
+Gnoppix Linux also adds a couple of Microsoft apps by default. In this release, you get the Microsoft Edge Browser 107 and the Microsoft Teams preview edition for meetings and communications.
+
+You have a complete change log with a huge list of package updates you can find in the [changelog][6].
+
+### Download
+
+If you want to try it, you can download it using the following link.
+
+[Download Gnoppix 22.12][7]
+
+Remember, it is ideal to be used in live media. However, you can easily install it on your hardware and run it as a Debian-GNOME-rolling release. Also, please note that it needs a minimum of 50GB of disk space for installation! That’s a hard requirement of its Calamares installer.
+
+Furthermore, the Kali Linux’s repo has already been added to the /etc/apt/sources.list – hence you can be sure of almost stable packages from Debian-rolling. So, it should be well stable.
+
+Cheers.
+
+Via [annoucement][6].
+
+--------------------------------------------------------------------------------
+
+via: https://debugpointnews.com/gnoppix-22-12-release/
+
+作者：[arindam][a]
+选题：[lkxed][b]
+译者：[译者ID](https://github.com/译者ID)
+校对：[校对者ID](https://github.com/校对者ID)
+
+本文由 [LCTT](https://github.com/LCTT/TranslateProject) 原创编译，[Linux中国](https://linux.cn/) 荣誉推出
+
+[a]: https://debugpointnews.com/author/dpicubegmail-com/
+[b]: https://github.com/lkxed
+[1]: https://debugpointnews.com/wp-content/uploads/2022/12/gnoppix-head1.jpg
+[2]: https://debugpointnews.com/wp-content/uploads/2022/12/Gnoppix-22.12-desktop.jpg
+[3]: https://www.gnoppix.com/
+[4]: https://debugpointnews.com/gnome-43-release/
+[5]: https://debugpointnews.com/wp-content/uploads/2022/12/GNOME-43.2-workspace-view.jpg
+[6]: https://sourceforge.net/p/gnoppixng/releases/general/thread/bc187de53a/#f258
+[7]: https://sourceforge.net/projects/gnoppixng/files/releases/


### PR DESCRIPTION
This article is collected by lkxed.