### PR TITLE
[手动选题][news]: 20221213.0 ⭐️ Puppy Linux 22.12 (S15Pup) Arrives Based on Slackware 15.md

### DIFF
--- a/sources/news/20221213.0 ⭐️ Puppy Linux 22.12 (S15Pup) Arrives Based on Slackware 15.md
+++ b/sources/news/20221213.0 ⭐️ Puppy Linux 22.12 (S15Pup) Arrives Based on Slackware 15.md
@@ -1,0 +1,82 @@
+[#]: subject: "Puppy Linux 22.12 (S15Pup) Arrives Based on Slackware 15"
+[#]: via: "https://debugpointnews.com/puppy-linux-22-12-s15pup/"
+[#]: author: "arindam https://debugpointnews.com/author/dpicubegmail-com/"
+[#]: collector: "lkxed"
+[#]: translator: " "
+[#]: reviewer: " "
+[#]: publisher: " "
+[#]: url: " "
+
+Puppy Linux 22.12 (S15Pup) Arrives Based on Slackware 15
+======
+
+![][1]
+
+**A new Puppy Linux flavour (Puppy Linux 22.12 S15Pup) is now available based on Slackware 15.**
+
+Puppy Linux is a super lightweight distro which runs entirely on RAM and requires a very low memory footprint. It is almost loaded with all the necessary applications for everything you need. It is quite remarkable that the Puppy Linux team managed to package all these applications, which run in low memory and surprisingly within 400 MB of ISO size. There are many variants of Puppy Linux based on Ubuntu and other distros – thanks to the fantastic Puppy Builder Woof-CE.
+
+### Puppy Linux 22.12 (s15pup): What’s New
+
+The recent release of Puppy Linux 22.12 is based on the Slackware 15.0 components, which were released in February 2022. At its core, the JWM (Joe’s Window Manager) provides flexibility and good performance in Puppy Linux because it runs off the RAM.
+
+![Puppy Linux 22.12 based on Slackware 15][2]
+
+Based on Slackware, Puppy 22.12 comes with Linux Kernel LTS series 5.15 for the 64-bit. And the 5.10 for the 32-bit system. The desktop feel is the same as other Puppy flavours based on the JWM 2.4.3. The JWM is used in other distro-based Puppy flavours as well.
+
+In addition, FFmpeg is loaded with Mplayer for your media playing needs – if at all required in a LIVE system. Also, the “Light” web browser, based on Firefox, gives you easy and performant access to the internet. Alternative browser installation options are also present.
+
+Furthermore, Puppy Linux 22.12 s15pup pre-loads most of the LXDE apps and components for the overall lightweight experience, such as Lxrandr 0.3.2, Lxtask 0.1.10 and Lxterminal 0.4.0.
+
+ISO of this Slackware flavour is less than 400 MB in size, and, amazingly, all of the following applications are pre-loaded on it. Here’s a summary of the key packages in this version:
+
+| Abiword 3.0.1 | Gparted 1.3.1 | Parcellite 1.2.1 |
+| Bash 5.1.016 | Grep 3.7 | Rox-filer 17w |
+| Busybox 1.35.0 | Gtk+2 2.24.33 | Samba 4.12.15 |
+| Cups 2.4.2 | Gtk+3 3.24.31 | Sed 4.8 |
+| Curl 7.86.0 | Gtkdialog 0.8.5a | Sylpheed 3.7.0 |
+| Dhcpcd 9.4.1 | Icu4c 69.1 | Syslinux 4.07 |
+| Didiwiki 0.8 | Jwm 2.4.3 | Transmission 2.60 |
+| Evince 2.32.0 | Lxrandr 0.3.2 | Util-linux 2.37.4 |
+| Ffmpeg 4.4.3 | Lxtask 0.1.10 | Viewnior 1.7 |
+| Gcc 11.2.0 | Lxterminal 0.4.0 | Xdelta 30.16 |
+| Geany 1.35 | Mesa 21.3.5 | Xsane 0.999 |
+| Ghostscript 9.55.0 | MPlayer 1.4 |
+| Glib2 2.70.3 | Mtpaint 3.50.09 |
+| Glibc 2.33 | Ncurses 6.3 |
+| Gnumeric 1.10.17 | Openssl 1.1.1s |
+
+### Download
+
+Puppy Linux is one of those few distros which still provides a 32-bit installation file alongside 64-bit. You can download this version from the following links for the respective architectures.
+
+- [S15Pup 64-bit – based on Slackware 15.0][3]
+- [S15Pup 32-bit – based on Slackware 15.0][4]
+- [ScPup 64-bit – based on Slackware current][5]
+- [ScPup 32-bit – based on Slackware current][6]
+
+If you are running it on a virtual machine, make sure to change the CPU architecture to 64-bit before installing it.
+
+_Via [release announcement][7] & [release notes][8]_
+
+--------------------------------------------------------------------------------
+
+via: https://debugpointnews.com/puppy-linux-22-12-s15pup/
+
+作者：[arindam][a]
+选题：[lkxed][b]
+译者：[译者ID](https://github.com/译者ID)
+校对：[校对者ID](https://github.com/校对者ID)
+
+本文由 [LCTT](https://github.com/LCTT/TranslateProject) 原创编译，[Linux中国](https://linux.cn/) 荣誉推出
+
+[a]: https://debugpointnews.com/author/dpicubegmail-com/
+[b]: https://github.com/lkxed
+[1]: https://debugpointnews.com/wp-content/uploads/2022/12/pups15head.jpg
+[2]: https://debugpointnews.com/wp-content/uploads/2022/12/Puppy-Linux-22.12-based-on-Slackware-15.jpg
+[3]: https://sourceforge.net/projects/spup/files/S15Pup64/
+[4]: https://sourceforge.net/projects/spup/files/S15Pup32/
+[5]: https://sourceforge.net/projects/spup/files/ScPup64/
+[6]: https://sourceforge.net/projects/spup/files/ScPup/
+[7]: https://forum.puppylinux.com/viewtopic.php?t=7464&sid=5ee2c343a8dbc0babc476139d188c50f
+[8]: http://distro.ibiblio.org/puppylinux/puppy-s15pup/release-S15Pup-22.12.htm


### PR DESCRIPTION
This article is collected by lkxed.