### PR TITLE
[手动选题][news]: 20230105.2 ⭐️ Nitrux 2.6.0 Takes Bold Steps Drops apt, Adds Flathub and Pipewire.md

### DIFF
--- a/sources/news/20230105.2 ⭐️ Nitrux 2.6.0 Takes Bold Steps Drops apt, Adds Flathub and Pipewire.md
+++ b/sources/news/20230105.2 ⭐️ Nitrux 2.6.0 Takes Bold Steps Drops apt, Adds Flathub and Pipewire.md
@@ -1,0 +1,81 @@
+[#]: subject: "Nitrux 2.6.0 Takes Bold Steps: Drops apt, Adds Flathub and Pipewire"
+[#]: via: "https://debugpointnews.com/nitrux-2-6-0-release/"
+[#]: author: "arindam https://debugpointnews.com/author/dpicubegmail-com/"
+[#]: collector: "lkxed"
+[#]: translator: " "
+[#]: reviewer: " "
+[#]: publisher: " "
+[#]: url: " "
+
+Nitrux 2.6.0 Takes Bold Steps: Drops apt, Adds Flathub and Pipewire
+======
+
+![][1]
+
+**Nitrux 2.6.0 arrives with Flathub, Pipewire by default, latest Kernel and KDE framework.**
+
+![Nitrux 2.6.0 Desktop][2]
+
+[Nitrux Linux][3]is based on Debian, which features a modified version of the KDE Plasma desktop called NX Desktop. This unique Linux distribution brings its own set of Nitrux applications built upon Maui kit and Qt. Nitrux is systemd-free and uses OpenRC as an init system. With all these unique features and stunning looks, it is one of the best Linux distributions today.
+
+Nitrux 2.6.0 is bumped up to be a considerable major version due to critical updates since its prior release, 2.5.1 in December.
+
+### Nitrux 2.6.0: What’s New
+
+A major focus of this release is the introduction of the Plasma Wayland session in the SDDM display manager. It’s not default yet. But available as optional. X11 is still default. I believe in the next major release; the NItrux team can enable Wayland by default.
+
+In addition, the modern sound manager Pipewire is now default, as it was already standardized in Ubuntu and Fedora and feels stable. Thanks to Pipewire, your audio workflow will be much better.
+
+Nitrux 2.6.0 also enables the largest Flatpak app repo – Flathub, by default. That means you do not need to set up Flatpak & enable Flathub anymore manually. Installation of the Flatpak apps is now much easier.
+
+Other noteworthy changes include, Nitrux making the root (/) partition immutable to prevent it from breakage, the Samba package now part of Nitrux default install, and the Calamares installer getting a customized auto partition scheme.
+
+![Nitrux 2.6 install automatic partition][4]
+
+From the beginning, Nitrux prefers self-contained executables for its entire desktop components. The primary choice was the AppImage file format. You get Flathub set up by default in this release, whereas the popular apt package manager is now dropped. This might change some users’ workflow because the apt command won’t work; despite being based on Debian.
+
+Hence, the Nitrux team suggested using the Distrobox containers to set up the separate skeleton to be used with apt. However, it will be a little difficult for general users to understand the container, immutable root partition.
+
+![apt is not dropped][5]
+
+The irony is apt will be used during installation because Calamares needs it. However, it will be removed after installation is complete.
+
+> The Live ISO _includes APT and dpkg, but this is because Calamares needs them to complete the installation and will be removed from the installed system._Nitrux team
+
+At its core, Nitrux 2.6.0 features liqurix Kernel 6.1 aligned with gaming and multimedia. This version is powered by KDE Plasma 2.26.4, KDE Framework 5.101.0 and Qt 5.15.7 LTS.
+
+Detailed release notes are available [here][6] if you want to read more.
+
+### Download
+
+You can download this version from the following pages. However, there is no upgrade path available. Hence it is recommended to do a fresh installation.
+
+- [FOSS Torrents (Torrent)][7]
+- [Sourceforge (mirror)][8]
+- [OSDN (mirror)][9]
+
+Via [announcement][10]
+
+--------------------------------------------------------------------------------
+
+via: https://debugpointnews.com/nitrux-2-6-0-release/
+
+作者：[arindam][a]
+选题：[lkxed][b]
+译者：[译者ID](https://github.com/译者ID)
+校对：[校对者ID](https://github.com/校对者ID)
+
+本文由 [LCTT](https://github.com/LCTT/TranslateProject) 原创编译，[Linux中国](https://linux.cn/) 荣誉推出
+
+[a]: https://debugpointnews.com/author/dpicubegmail-com/
+[b]: https://github.com/lkxed
+[1]: https://debugpointnews.com/wp-content/uploads/2023/01/nitrux-head.jpg
+[2]: https://debugpointnews.com/wp-content/uploads/2023/01/Nitrux-2.6.0-Desktop.jpg
+[3]: https://nxos.org/
+[4]: https://debugpointnews.com/wp-content/uploads/2023/01/Nitrux-2.6-install-automatic-partition.jpg
+[5]: https://debugpointnews.com/wp-content/uploads/2023/01/Screenshot-from-2023-01-05-13-44-57.png
+[6]: https://nxos.org/notes/notes-nitrux-2-6-0
+[7]: https://fosstorrents.com/distributions/nitrux/
+[8]: https://sourceforge.net/projects/nitruxos/files/Release/ISO
+[9]: https://osdn.net/projects/nitrux/releases/p18379
+[10]: https://nxos.org/changelog/release-announcement-nitrux-2-6-0/


### PR DESCRIPTION
This article is collected by lkxed.