### PR TITLE
RP:published/20221118.0 ⭐️⭐️ Fixing “Key is stored in legacy trusted.gpg keyring” Issue in Ubuntu.md

### DIFF
--- a/published/20221118.0 ⭐️⭐️ Fixing “Key is stored in legacy trusted.gpg keyring” Issue in Ubuntu.md
+++ b/published/20221118.0 ⭐️⭐️ Fixing “Key is stored in legacy trusted.gpg keyring” Issue in Ubuntu.md
@@ -3,12 +3,14 @@
 [#]: author: "Abhishek Prakash https://itsfoss.com/"
 [#]: collector: "lkxed"
 [#]: translator: "geekpi"
-[#]: reviewer: " "
-[#]: publisher: " "
-[#]: url: " "
+[#]: reviewer: "wxy"
+[#]: publisher: "wxy"
+[#]: url: "https://linux.cn/article-15565-1.html"
 
 修复 Ubuntu 中的 “Key is stored in legacy trusted.gpg keyring” 问题
 ======
+
+![][0]
 
 如果你在 Ubuntu 22.04 及以后的版本中使用 PPA 或添加外部仓库，你有可能会看到这样的信息：
 
@@ -18,7 +20,7 @@ W: https://packagecloud.io/slacktechnologies/slack/debian/dists/jessie/InRelease
 
 ![ubuntu key is stored legacy][1]
 
-首先，这不是一个错误，而是一个警告信息。警告并不会停止程序。即使你在更新过程中看到这个警告信息，你也可以继续升级你的系统。
+首先，这不是一个错误，而是一个警告信息。警告并不会导致程序停止工作。即使你在更新过程中看到这个警告信息，你也可以继续升级你的系统。
 
 如果你不想看到这个警告信息，你可以采取一些手动步骤来摆脱它。
 
@@ -35,18 +37,18 @@ sudo apt-key list
 这将显示一个存储在你系统中的巨大的密钥列表。你在这里要做的是寻找与警告信息相关的密钥。
 
 ```
-[email protected]:~$ sudo apt-key list
+abhishek@itsfoss:~$ sudo apt-key list
 [sudo] password for abhishek: 
 Warning: apt-key is deprecated. Manage keyring files in trusted.gpg.d instead (see apt-key(8)).
 /etc/apt/trusted.gpg
 --------------------
 pub   rsa4096 2014-01-13 [SCEA] [expired: 2019-01-12]
       418A 7F2F B0E1 E6E7 EABF  6FE8 C2E7 3424 D590 97AB
-uid           [ expired] packagecloud ops (production key) <[email protected]>
+uid           [ expired] packagecloud ops (production key) <abhishek@itsfoss>
 
 pub   rsa4096 2016-02-18 [SCEA]
       DB08 5A08 CA13 B8AC B917  E0F6 D938 EC0D 0386 51BD
-uid           [ unknown] https://packagecloud.io/slacktechnologies/slack (https://packagecloud.io/docs#gpg_signing) <[email protected]>
+uid           [ unknown] https://packagecloud.io/slacktechnologies/slack (https://packagecloud.io/docs#gpg_signing) <abhishek@itsfoss>
 sub   rsa4096 2016-02-18 [SEA]
 
 /etc/apt/trusted.gpg.d/audio-recorder-ubuntu-ppa.gpg
@@ -61,37 +63,37 @@ pub   rsa1024 2010-10-08 [SC]
       59DA D276 B942 642B 1BBD  0EAC A8AA 1FAA 3F05 5C03
 ```
 
-你是怎么做的？仔细阅读该信息。
+你要怎么做？仔细阅读该信息：
 
 ```
 W: https://packagecloud.io/slacktechnologies/slack/debian/dists/jessie/InRelease: Key is stored in legacy
 ```
 
-在我的例子中，仓库有 packagecloud、slacktechnologies 等关键词。它显示在 apt-key 列表输出的顶部。在你的情况下，你可能需要滚动一下。
+在我的例子中，仓库有 `packagecloud`、`slacktechnologies` 等关键词。它显示在 `apt-key` 列表输出的顶部。在你的情况下，你可能需要滚动一下。
 
 在这种罕见的情况下，由 Slack 添加的外部仓库，有两个 GPG 密钥。其中一个已经过期，我会忽略它。你可能不会有这样的情况。
 
-你应该看到 pub 后一行的最后 8 个字符（不包括空格）。
+你应该看到 `pub` 后一行的最后 8 个字符（不包括空格）：
 
 ```
 /etc/apt/trusted.gpg
 --------------------
 pub   rsa4096 2014-01-13 [SCEA] [expired: 2019-01-12]
       418A 7F2F B0E1 E6E7 EABF  6FE8 C2E7 3424 D590 97AB
-uid           [ expired] packagecloud ops (production key) <[email protected]>
+uid           [ expired] packagecloud ops (production key) <abhishek@itsfoss>
 
 pub   rsa4096 2016-02-18 [SCEA]
       DB08 5A08 CA13 B8AC B917  E0F6 D938 EC0D 0386 51BD
-uid           [ unknown] https://packagecloud.io/slacktechnologies/slack (https://packagecloud.io/docs#gpg_signing) <[email protected]>
+uid           [ unknown] https://packagecloud.io/slacktechnologies/slack (https://packagecloud.io/docs#gpg_signing) <abhishek@itsfoss>
 ```
 
-因此，从 “DB08 5A08 CA13 B8AC B917 E0F6 D938 EC0D 0386 51BD” 这行中，我将提取最后8个字符 “0386 51BD”，去掉空格，然后用它来导入 /etc/apt/trusted.gpg.d 目录下专用文件中的 GPG 密钥：
+因此，从 `DB08 5A08 CA13 B8AC B917 E0F6 D938 EC0D 0386 51BD` 这行中，我将提取最后8个字符 `0386 51BD`，去掉空格，然后用它来导入 `/etc/apt/trusted.gpg.d` 目录下专用文件中的 GPG 密钥：
 
 ```
 sudo apt-key export 038651BD | sudo gpg --dearmour -o /etc/apt/trusted.gpg.d/slack.gpg
 ```
 
-我在这里创建了一个新的文件 slack.gpg，以防你没有注意到它。我把它命名为 slack.gpg 是因为它与我之前安装的 Slack 应用有关。文件名并不重要，但它对识别有好处。
+我在这里创建了一个新的文件 `slack.gpg`，以防你没有注意到它。我把它命名为 `slack.gpg` 是因为它与我之前安装的 Slack 应用有关。文件名并不重要，但它对识别有好处。
 
 如果命令运行成功，你将不会看到任何信息。你可以通过检查新创建的 gpg 文件是否存在来验证。
 
@@ -103,7 +105,7 @@ sudo apt-key export 038651BD | sudo gpg --dearmour -o /etc/apt/trusted.gpg.d/sla
 
 如果你觉得手动做上面的事情不舒服，那么，你可以忽略这个警告信息。我的意思是，忽略它总是一种选择。
 
-另一个选择是把 /etc/apt/trusted.gpg 文件复制到 /etc/apt/trusted.gpg.d 目录。毕竟，Ubuntu 只抱怨说它需要 /etc/apt/trusted.gpg.d 目录下的 GPG 密钥。
+另一个选择是把 `/etc/apt/trusted.gpg` 文件复制到 `/etc/apt/trusted.gpg.d` 目录。毕竟，Ubuntu 只是抱怨说它需要 `/etc/apt/trusted.gpg.d` 目录下的 GPG 密钥。
 
 你仍然要使用终端。打开它并使用以下命令：
 
@@ -117,9 +119,9 @@ sudo cp /etc/apt/trusted.gpg /etc/apt/trusted.gpg.d
 
 ### 总结
 
-我曾经写过一篇关于[apt-key 弃用][4]的详细文章。显然，那篇文章让一些读者感到困惑，因此我写了这篇文章，给他们提供摆脱该信息的直接步骤。
+我曾经写过一篇关于 [弃用 apt-key][4] 的详细文章。显然，那篇文章让一些读者感到困惑，因此我写了这篇文章，给他们提供摆脱该信息的直接步骤。
 
-正如我之前所说，这是一个警告信息，目前可以忽略。解决这个问题的责任在于外部软件开发者和 Ubuntu 开发者。外部软件开发者应该确保他们的 GPG 密钥不再被添加到 /etc/apt/trusted.gpg 文件中。
+正如我之前所说，这是一个警告信息，目前可以忽略。解决这个问题的责任在于外部软件开发者和 Ubuntu 开发者。外部软件开发者应该确保他们的 GPG 密钥不再被添加到 `/etc/apt/trusted.gpg` 文件中。
 
 终端用户不应该为他们的懒惰而承担痛苦。
 
@@ -132,13 +134,14 @@ via: https://itsfoss.com/key-is-stored-in-legacy-trusted-gpg/
 作者：[Abhishek Prakash][a]
 选题：[lkxed][b]
 译者：[geekpi](https://github.com/geekpi)
-校对：[校对者ID](https://github.com/校对者ID)
+校对：[wxy](https://github.com/wxy)
 
 本文由 [LCTT](https://github.com/LCTT/TranslateProject) 原创编译，[Linux中国](https://linux.cn/) 荣誉推出
 
 [a]: https://itsfoss.com/
 [b]: https://github.com/lkxed
-[1]: https://itsfoss.com/wp-content/uploads/2022/11/ubuntu-key-is-stored-legacy.png
-[2]: https://itsfoss.com/wp-content/uploads/2022/11/import-gpg-key-to-trusted-ubuntu.png
-[3]: https://itsfoss.com/wp-content/uploads/2022/11/quick-dirty-way-to-fix-apt-key-stored-legacy.png
+[1]: https://itsfoss.com/content/images/wordpress/2022/11/ubuntu-key-is-stored-legacy.png
+[2]: https://itsfoss.com/content/images/wordpress/2022/11/import-gpg-key-to-trusted-ubuntu.png
+[3]: https://itsfoss.com/content/images/wordpress/2022/11/quick-dirty-way-to-fix-apt-key-stored-legacy.png
 [4]: https://itsfoss.com/apt-key-deprecated/
+[0]: https://img.linux.net.cn/data/attachment/album/202302/22/143209ysmxzrasycrxz7wa.jpg


### PR DESCRIPTION
@geekpi
https://linux.cn/article-15565-1.html