### PR TITLE
[手动选题][news]: 20230220.0 ⭐️⭐️ Linux Kernel 6.2 is Out with IPv6 Protective Load Balancing, Improved Rust Support.md

### DIFF
--- a/sources/news/20230220.0 ⭐️⭐️ Linux Kernel 6.2 is Out with IPv6 Protective Load Balancing, Improved Rust Support.md
+++ b/sources/news/20230220.0 ⭐️⭐️ Linux Kernel 6.2 is Out with IPv6 Protective Load Balancing, Improved Rust Support.md
@@ -1,0 +1,191 @@
+[#]: subject: "Linux Kernel 6.2 is Out with IPv6 Protective Load Balancing, Improved Rust Support"
+[#]: via: "https://www.debugpoint.com/linux-kernel-6-2/"
+[#]: author: "Arindam https://www.debugpoint.com/author/admin1/"
+[#]: collector: "lkxed"
+[#]: translator: " "
+[#]: reviewer: " "
+[#]: publisher: " "
+[#]: url: " "
+
+Linux Kernel 6.2 is Out with IPv6 Protective Load Balancing, Improved Rust Support
+======
+
+**A new Linux Kernel 6.2 arrived with updated Rust language support, IPv6 protective load balancing and more.**
+
+Linus Torvalds released Linux Kernel 6.2 on Feb 19, 2023, as the first mainline Kernel release of 2023. The merge and testing window is a little larger, considering a few bugs and fixes, but it arrives almost in time to be featured in the upcoming major distro releases.
+
+Overall changes are usual, catered to GPU, CPU lineups, more Rust infra support, and port and file-system updates.
+
+> And this obviously means that the 6.3 merge window will open tomorrow,and I already have 30+ pull requests queued up, which I reallyappreciate. I like how people have started to take the whole “readyfor the merge window” to heart.But in the meantime, please do give 6.2 a testing. Maybe it’s not asexy LTS release like 6.1 ended up being, but all those regularpedestrian kernels want some test love too.[Linus while announcing the 6.2][1]
+
+Let’s take a look at what’s new.
+
+### Linux Kernel 6.2: New Features
+
+#### CPU and subsystems
+
+A considerable amount of power management code [arrives][2] in Linux Kernel 6.2 across CPUs and architectures. Intel Alder Lake N and Raptor Lake P models changed the Energy Performance Bias (EPB) value from 6 to 7, which helps to reduce power consumption. In addition, Apple M1/M2 brings CPU frequency scaling for the P-State to control the power consumption in Apple silicon.
+
+A bunch of code [dropped][3] for the message signalled interrupts (MSI) subsystem of the Kernel to support per-device interrupt domains. The revamp of MSI was in discussion for some time for implementation due to its initial design issue.
+
+AMD’s Zen 4 processors are now supported by Kernel 6.2 with various opening up of [performance modules][4]. Essential items that get support for this processor are core performance monitor counters, L3 cache performance monitor counters, multiple event metrics around dispatch, branch prediction, L1/L2 cache activity and many more.
+
+AMD’s P-state driver code was added to Kernel for the past few releases. In this version, a bunch of [patches][5] arrive at this p-State Energy Performance Preference handling module.
+
+More RISC-V architecture support arrives in this Kernel release bringing persistent memory device support, T-Head PMU support and [additional changes][6].
+
+Furthermore, a handful of system on a chip (SoC) support arrives in this release. Significant models include Qualcomm Snapdragon 460, 650, 652, 821, 662, 695, 670, Apple M1 Pro, Max, Ultra SoCs, a bunch of Rockchip boards and [many more][7].
+
+#### GPU
+
+The graphics stack also gets significant updates, including the ongoing code addition for upcoming models from Intel and AMD.
+
+Firstly, Intel’s Arc Graphics (DG2/Alchemist) card support becomes stable and removed as experimental support. Hence it’s ready to be used with the latest mainline Kernel from this version onwards.
+
+Also arriving, the initial NVIDIA RTX 30 “Ampere” accelerated support, more Intel [Meteor Lake code base][8] and AMD is also patched more code for RDNA3 cards.
+
+#### Port, filesystem
+
+A vast number of file system change arrives in this release. The significant update includes the NTFS driver adding new mount options, better performance for exFAT while creating files/directories, better caching for F2FS, performance and fixes for btrfs file system.
+
+The USB4 [updates][9] continue to arrive, and 6.2 is bringing wake on connect and disconnect via USB4 ports. In addition, the USB 2.0 dongle to VGA adapter “sisusbvga” driver support is dropped in this release, being outdated hardware.
+
+The IPv6 stack in the networking module [gets “protective load balancing” (PLB) support][10]. PLB is a host-based system for load balancing across switches, leveraging congestion signals from the transport layer by changing the path of connections.
+
+#### Other changes
+
+Since kernel 6.1 added the initial Rust skeleton, this release also adds more initial support for Rust for the future. The changes include new macros, and constructors for the Kernel support with Rust which you can find here (via the [mailing list][11]):
+
+**String and formatting:** new types `CString`, `CStr`, `BStr` and `Formatter`; new macros `c_str!`, `b_str!` and `fmt!`.**Errors**: the rest of the error codes from `errno-base.h`, as well as some `From` trait implementations for the `Error` type.**Printing**: the rest of the `pr_*!` levels and the continuation one `pr_cont!`, as well as a new sample.`alloc` crate: new constructors `try_with_capacity()` and `try_with_capacity_in()` for `RawVec` and `Vec`.**Procedural macros:** new macros `#[vtable]` and `concat_idents!`, as well as better ergonomics for `module!` users.**Asserting**: new macros `static_assert!`, `build_error!` and `build_assert!`, as well as a new crate `build_error` to support them.**Vocabulary types**: new types `Opaque` and `Either`.Debugging: new macro `dbg!`.
+
+On top of the above changes, Kernel 6.2 started dropping code for 800Gbps networking support and MotorComm YT8521 Gigabit ethernet support and Wi-Fi 7.
+
+A brief list of hardware support is present in this list:
+
+Clock, Pin control and GPIO
+
+- MStar CPUPLL clocks
+- Ingenic JZ4755 CGU clocks
+- MediaTek FHCTL hardware controller clocks
+- Qualcomm SC8280XP and SM6375 display clock controllers
+
+- Qualcomm SDM670 pin controllers
+- Loongson-2 SoC pin controllers
+- Intel Moorefield pin controllers
+
+Graphics:
+
+- Open Firmware display controllers
+- Renesas RZ/G2L MIPI DSI encoders
+- Jadard JD9365DA-H3 WXGA DSI panels
+- NewVision NV3051D DSI panels
+
+Hardware monitoring:
+
+- Ampere Altra SMpro hardware monitors
+- OneXPlayer EC fan controllers
+
+Input:
+
+- Hynitron cst3xx touchscreens
+- Cypress TrueTouch Gen5 touchscreens
+- Himax hx83112b touchscreens
+
+Media:
+
+- OmniVision OV08X40 and OV4689 sensors
+- STmicroelectronics VGXY61 sensors
+- Toshiba TC358746 parallel-CSI2 bridges
+- Allwinner A31 image signal processors
+- Microchip image sensor controllers
+- Renesas RZ/G2L MIPI CSI-2 receivers
+
+Miscellaneous:
+
+- ARM CoreSight performance monitoring units
+- Amlogic DDR bandwidth performance monitors
+- Loongson-2 SoC global utilities register blocks
+- Dell WMI-based platform sensors
+- ChromeOS human-presence sensors
+- Apple CPU-frequency controllers
+- ARM SCMI powercap controllers
+- Richtek RT6190 4-Switch BuckBoost controllers
+- MediaTek MT6357 power-management ICs
+- Sunplus SP7021 MMC controllers
+
+Networking:
+
+- Realtek 8852BE PCI wireless network adapters
+- Motorcomm yt8521 gigabit Ethernet PHYs
+- Renesas R-Car S4-8 Ethernet switches
+- MediaTek MT7996 wireless interfaces
+- NVIDIA Tegra multi-gigabit Ethernet controllers
+- Realtek 8821CU, 8822BU, 8822CU and 8723DU USB wireless network adapters
+- Broadcom BCM4377/4378/4387 Bluetooth interfaces
+
+Sound:
+
+- Realtek RT1318 codecs
+
+### How to Download and Install Linux Kernel 6.2
+
+Remember that using the bleeding-edge mainline Linux Kernel in your production systems/daily-drive laptops/desktops is not wiser unless you have a specific requirement. Or have the latest GPU, CPU, which requires support.
+
+For general users, it’s always best to wait for a few weeks until all the major Linux Distributions bring this version via their official stable channel after proper testing.
+
+That being said, if you still want to install this version, go ahead and follow the below instructions in Debian-based distributions, which I lined up here.
+
+- There are two types of builds available – **generic** and **lowlatency**. You can download generic builds that work most of the time for standard systems.
+- For audio recordings and other setups that require low latency (like real-time feeds), download the lowlatency one.
+
+- Firstly, visit the [mainline kernel page][12].
+- Secondly, download the below four packages for generic via the terminal and install them.
+
+```
+wget -c https://kernel.ubuntu.com/~kernel-ppa/mainline/v6.2/amd64/linux-headers-6.2.0-060200-generic_6.2.0-060200.202302191831_amd64.debwget -c https://kernel.ubuntu.com/~kernel-ppa/mainline/v6.2/amd64/linux-headers-6.2.0-060200_6.2.0-060200.202302191831_all.debwget -c https://kernel.ubuntu.com/~kernel-ppa/mainline/v6.2/amd64/linux-image-unsigned-6.2.0-060200-generic_6.2.0-060200.202302191831_amd64.debwget -c https://kernel.ubuntu.com/~kernel-ppa/mainline/v6.2/amd64/linux-modules-6.2.0-060200-generic_6.2.0-060200.202302191831_amd64.deb
+```
+
+```
+sudo dpkg -i *.deb
+```
+
+- After installation, reboot the system.
+- The instruction for lowlatency and other architecture (e.g., ARM) installations are the same. Replace the package name in the above wget commands. You can find them on the mainline Kernel page.
+
+#### Distro support
+
+Arch Linux users should get this version by 1st week of March-2023 via monthly ISO refresh.
+
+Ubuntu 23.04 Lunar Lobster may feature this Kernel, due on April-2023. However, Fedora 38 may feature this version which is due in March. But I think both are unlikely.
+
+### Wrapping Up
+
+This release opens the merge window for the following Linux Kernel 6.3, which is expected to bring more updates to the Rust framework and additional hardware support.
+
+Cheers.
+
+--------------------------------------------------------------------------------
+
+via: https://www.debugpoint.com/linux-kernel-6-2/
+
+作者：[Arindam][a]
+选题：[lkxed][b]
+译者：[译者ID](https://github.com/译者ID)
+校对：[校对者ID](https://github.com/校对者ID)
+
+本文由 [LCTT](https://github.com/LCTT/TranslateProject) 原创编译，[Linux中国](https://linux.cn/) 荣誉推出
+
+[a]: https://www.debugpoint.com/author/admin1/
+[b]: https://github.com/lkxed/
+[1]: https://lore.kernel.org/lkml/CAHk-=wio46vC4t6xXD-sFqjoPwFm_u515jm3suzmkGxQTeA1_A@mail.gmail.com/T/
+[2]: https://lore.kernel.org/lkml/Y5iFrMDV+YOdncjA@zn.tnic/
+[3]: https://lore.kernel.org/lkml/167083908037.564878.14292182209678650008.tglx@xen13.tec.linutronix.de/
+[4]: https://lore.kernel.org/lkml/20221222164914.508929-1-acme@kernel.org/
+[5]: https://lore.kernel.org/lkml/20221219064042.661122-1-perry.yuan@amd.com/T/#t
+[6]: https://lore.kernel.org/lkml/mhng-f76eb33c-7cc1-426f-8f29-37f6bb78baec@palmer-ri-x1c9/T/#u
+[7]: https://lore.kernel.org/lkml/257c9d3c-5bfa-4c5a-8ba3-11982a00b1d3@app.fastmail.com/
+[8]: https://lists.freedesktop.org/archives/dri-devel/2022-November/380383.html
+[9]: https://lore.kernel.org/lkml/Y5wvvK08gUxb7feH@kroah.com/
+[10]: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=957ed5e7129f
+[11]: https://lore.kernel.org/rust-for-linux/20221211005609.270457-1-ojeda@kernel.org/
+[12]: https://kernel.ubuntu.com/~kernel-ppa/mainline/v6.0


### PR DESCRIPTION
This article is collected by lkxed.