### PR TITLE
[手动选题][news]: 20230307.0 ⭐️ Linux Kernel 6.3 Rc1 Released with Intel VPU Driver, Rust Updates.md

### DIFF
--- a/sources/news/20230307.0 ⭐️ Linux Kernel 6.3 Rc1 Released with Intel VPU Driver, Rust Updates.md
+++ b/sources/news/20230307.0 ⭐️ Linux Kernel 6.3 Rc1 Released with Intel VPU Driver, Rust Updates.md
@@ -1,0 +1,116 @@
+[#]: subject: "Linux Kernel 6.3 Rc1 Released with Intel VPU Driver, Rust Updates"
+[#]: via: "https://www.debugpoint.com/linux-kernel-6-3-rc1/"
+[#]: author: "Arindam https://www.debugpoint.com/author/admin1/"
+[#]: collector: "lkxed"
+[#]: translator: " "
+[#]: reviewer: " "
+[#]: publisher: " "
+[#]: url: " "
+
+Linux Kernel 6.3 Rc1 Released with Intel VPU Driver, Rust Updates
+======
+
+**Linus Torvalds releases Linux Kernel 6.3 RC1 for everyone to test, which brings regular updates, more Rust code and more.**
+
+Following the [Linux Kernel 6.2 release][1] two weeks back, the merge window for Linux Kernel 6.3 is now closed. While announcing the release candidate, Linus is fairly happy with a standard “two weeks” merge window without any significant events happening.
+
+> And of course, smooth or not, now that the merge window is closed, we need to make sure it all _works_. We had a couple of exciting mergesalready, and I think the fallout from that got sorted out, but I’m sure there’s more to come. Let’s hope the calming-down period of 6.3 works as well as the merge window did… Knock wood.Anyway, as always, the shortlog is much too large to post, since we had 12500+ commits (and that’s not counting the merges – closer to a thousand of those). So below is just my usual merge log which gives only a very high-level view of what I merged and from who. It all looks fairly normal, with ~55% of the patch being drivers, ~20% being architecture updates. and the rest being the usual random mix (documentation, tooling, networking, filesystem, and just core kernel stuff).[Linus, while announcing release candidate][2]
+
+Let’s take a look at what’s new.
+
+### Linux Kernel 6.3 Rc1: Key Updates
+
+#### CPU and GPU
+
+AMD Zen 4 server processors get a new feature for Slow Memory Bandwidth Allocation Enforcement support, enabling compatibility with the data centre workloads. The code has been coming up since last year, but now it is mainlined.
+
+Continuous performance improvement [seen][3] on AMD 4th Gen FPYC and Ryzen products for implementing automatic IBRS (Indirect Branch Restricted Speculation) for Spectre V2 fixes.
+
+In this Kernel release, Intel’s new x86_64 instruction LKGS is [merged][4]. LKGS is part of the Flexible Return and Event Delivery specification, enabling lower latency transitions between CPU privilege levels. You can read more about FRED [here][5] if you are interested. It’s fascinating.
+
+Other key updates on Intel’s side are the TPMI driver is [merged][6] and Trust Domain Extensions (TDX) for 4th Gen Xeon Scalable “Sapphire Rapids” processors are updated.
+
+In addition to the above, a few ARM & SoC updates arrive in this Kernel release.
+
+Firstly, the highly discussed Qualcomm Snapdragon 8 Gen 2 support [arrives][7] in Kernel 6.3. This is significant because many leading mobile brands are planning their upcoming releases with this. For example, Samsung Galaxy S23 Plus, OnePlus 11 Pro, Xiaomi 13 Pro 5G and others.
+
+Here’s a quick list of SoCs and ARM board updates in Kernel 6.3. This is not a complete list. However, you can read in detail in [this][7] merge request if you need more information.
+
+- Qualcomm QDU1000/QRU1000 5G RAN
+- Rockchips RK3588/RK3588s for tablets, Chromebooks and SBCs
+- TI J784S4 for commercial usage
+- Banana Pi R3 router with Mediatek mt7986a
+- Qualcomm MSM8916 (Snapdragon 410)
+- SM6115 (Snapdragon 662)
+- SM8250 (Snapdragon 865)
+- MSM8916 LTE dongles
+
+Furthermore, Intel’s Meteor Lake VPU (Versatile processing unit) [arrives][8] in Kernel 6.3, which is aimed at Meteor Lake SoCs. This VPU is planned to be used in Artificial Intelligence computing.
+
+In addition, Intel’s Meteor Lake GPU display support is now available in this version.
+
+#### Core changes
+
+Since the initial Rust structure implementation in Kernel 6.1, more [improvements][9] and support pouring in to support the Rust module in Kernel. Some core Rust changes arrived, which is listed below:
+
+- Support for Arc, ArcBorrow, and UniqueArc types
+- ForeignOwnable and ScopeGuard types support
+- Improvements to the alloc module
+
+To benefit several Azure use cases and WSL, Microsoft provides [patches][10] for Hyper-V nested hypervisor support in Kernel 6.3.
+
+#### File system and networking
+
+Kernel 6.3 [introduces][11] ath12k driver support for Qualcomm WiFi 7 series of chipsets.
+
+The IPv4 protocol [sees][11] big performance improvements, thanks to the implementation of “IPv4 BIG TCP” patches; similar to IPv6.
+
+Kernel 6.3 [introduces][12] DisplayPort Bandwidth Allocation Mode for Thunderbolt drivers allowing GPU and Thunderbolt drivers to work together for dynamic bandwidth allocation.
+
+For the past couple of Kernel releases, Tesla FSD SoC getting updates and patches. In this release, the audio support arrives at the Tesla FSD SoCs, [submitted][13] by Samsung & Tesla. This and the earlier changes aim to reduce the burden of maintaining drivers by themselves. It also opens up possibilities to run custom Kernel in Tesla SoCs as well.
+
+Furthermore, Btrfs and EXt4 file systems get some bug fixes and performance improvements.
+
+### Download Linux Kernel 6.3 RC1 source
+
+You can download the RC source tree from the following [page][14].
+
+| mainline: | **6.3-rc1** | 2023-03-05 | [[tarball][15]] | [[patch][16]] | [[view diff][17]] | [[browse][18]] |
+
+If you are running benchmarks, testing new hardware and finding issues, report to the Kernel mailing list.
+
+Finally, the Linux Kernel 6.3 is expected to be released around April 2023 month. The Q4 2023 Linux distribution releases – Fedora 39, and Ubuntu 23.10 may get this version.
+
+Please test and report issues if you find any.
+
+--------------------------------------------------------------------------------
+
+via: https://www.debugpoint.com/linux-kernel-6-3-rc1/
+
+作者：[Arindam][a]
+选题：[lkxed][b]
+译者：[译者ID](https://github.com/译者ID)
+校对：[校对者ID](https://github.com/校对者ID)
+
+本文由 [LCTT](https://github.com/LCTT/TranslateProject) 原创编译，[Linux中国](https://linux.cn/) 荣誉推出
+
+[a]: https://www.debugpoint.com/author/admin1/
+[b]: https://github.com/lkxed/
+[1]: https://www.debugpoint.com/linux-kernel-6-2/
+[2]: https://lore.kernel.org/lkml/CAHk-=wgr1D8hb75Z+nn+4LXUnosp0HM+gP+YJEcEav1DgTC=Cw@mail.gmail.com/T/#u
+[3]: https://lore.kernel.org/lkml/20230222013802.jgqem3oj6vmcixpf@desk/T/
+[4]: https://lore.kernel.org/lkml/20221006154041.13001-1-xin3.li@intel.com/
+[5]: https://www.google.com/url?sa=t&rct=j&q=&esrc=s&source=web&cd=&cad=rja&uact=8&ved=2ahUKEwjJs4Ougsn9AhUcyzgGHZTrAFoQFnoECAcQAQ&url=https%3A%2F%2Fcdrdv2-public.intel.com%2F678938%2F346446-flexible-return-and-event-delivery.pdf&usg=AOvVaw3yQcvJYc2uOmaFyeUm212Q
+[6]: https://lore.kernel.org/lkml/20221209132524.20200-5-kirill.shutemov@linux.intel.com/
+[7]: https://lore.kernel.org/lkml/99179367-0d59-4938-b44c-ca9408ad784e@app.fastmail.com/
+[8]: https://lists.freedesktop.org/archives/intel-gfx/2023-January/317115.html
+[9]: https://lore.kernel.org/lkml/20230212183249.162376-1-ojeda@kernel.org/
+[10]: https://lore.kernel.org/lkml/Y%2FOCT7A%2F7GHNxgX4@liuwe-devbox-debian-v2/
+[11]: https://lore.kernel.org/lkml/20230221233808.1565509-1-kuba@kernel.org/
+[12]: https://lore.kernel.org/lkml/Y%2FiyrFP2wO97XvjD@kroah.com/T/#u
+[13]: https://lore.kernel.org/lkml/875ybzgcz7.wl-tiwai@suse.de/
+[14]: https://www.kernel.org/
+[15]: https://git.kernel.org/torvalds/t/linux-6.3-rc1.tar.gz
+[16]: https://git.kernel.org/torvalds/p/v6.3-rc1/v6.2
+[17]: https://git.kernel.org/torvalds/ds/v6.3-rc1/v6.2
+[18]: https://git.kernel.org/torvalds/h/v6.3-rc1


### PR DESCRIPTION
This article is collected by lkxed.