### PR TITLE
[手动选题][news]: 20230501.0 ⭐️ Nitrux 2.8 Launched with Updated Kernel, KDE Plasma and WayDroid support.md

### DIFF
--- a/sources/news/20230501.0 ⭐️ Nitrux 2.8 Launched with Updated Kernel, KDE Plasma and WayDroid support.md
+++ b/sources/news/20230501.0 ⭐️ Nitrux 2.8 Launched with Updated Kernel, KDE Plasma and WayDroid support.md
@@ -1,0 +1,60 @@
+[#]: subject: "Nitrux 2.8 Launched with Updated Kernel, KDE Plasma and WayDroid support"
+[#]: via: "https://debugpointnews.com/nitrux-2-8/"
+[#]: author: "arindam https://debugpointnews.com/author/dpicubegmail-com/"
+[#]: collector: "lkxed"
+[#]: translator: " "
+[#]: reviewer: " "
+[#]: publisher: " "
+[#]: url: " "
+
+Nitrux 2.8 Launched with Updated Kernel, KDE Plasma and WayDroid support
+======
+
+**Nitrux 2.8 now features the latest software updates, performance improvements, and enhanced tablet compatibility.**
+
+The Nitrux team has announced the release of Nitrux 2.8.0, the latest version of their Debian-based distribution. This new version brings several updates and improvements, making it an exciting release for users. One of the highlights of this release is the promise to become “tablet-friendly.”
+
+The team has combined the latest software updates, bug fixes, performance improvements, and hardware support to make Nitrux 2.8.0 the most stable and efficient release yet. The default kernel version is 6.2.13-1 (Liquorix), and KDE Plasma, KDE Frameworks, and KDE Gear have been updated to versions 5.27.4, 5.105.0, and 23.04.0, respectively. Additionally, Firefox has been updated to version 112.0.2.
+
+![Nitrux 2.8 desktop (live)][1]
+
+The team has also updated MESA to version 23.2. They’ve updated the Calamares custom layout, making changes to create only three partitions. They’ve also adjusted the automatic size ratio of the partitions when using the automated partition options “Erase disk” and “Replace partition.” The updated partition layout also changes what filesystems are used for which partitions.
+
+Nitrux 2.8.0 includes WayDroid by default, with support for starting the WayDroid container service using OpenRC. WayDroid is a container-based approach to boot a complete Android system on a regular GNU/Linux system like Ubuntu. However, it will not work in X11 but only in a Wayland session (hence the name, Wayland + Android). Additionally, the team has added Maliit Keyboard (not enabled by default) for better integration with touch devices.
+
+To further improve performance, the team has adjusted Sysctl settings by providing a custom file for a slight increment in performance. This includes changes to the rate at which VFS caches are reclaimed, enabling Asynchronous non-blocking I/O, and reducing the aggressivity when the kernel swaps out anonymous memory relative to pagecache and other caches. The team has also added and enabled zswap by default and updated the AMD Vulkan driver to version v-2023.Q2.1.
+
+Overall, Nitrux 2.8.0 brings a host of updates and improvements, making it an excellent release for users. With the promise of becoming “tablet-friendly,” the Nitrux team has shown their dedication to providing a distribution that is accessible and versatile.
+
+You can download this version from the below links.
+
+- [ISO — Direct HTTP Download][2]
+- [FOSS Torrents (Torrent)][3].
+- [Sourceforge (mirror)][4].
+- [OSDN (mirror)][5].
+
+Via [release notes][6], and [announcements][7].
+
+[_Using Mastodon? Follow us at floss.social/@debugpoint_][8]
+
+--------------------------------------------------------------------------------
+
+via: https://debugpointnews.com/nitrux-2-8/
+
+作者：[arindam][a]
+选题：[lkxed][b]
+译者：[译者ID](https://github.com/译者ID)
+校对：[校对者ID](https://github.com/校对者ID)
+
+本文由 [LCTT](https://github.com/LCTT/TranslateProject) 原创编译，[Linux中国](https://linux.cn/) 荣誉推出
+
+[a]: https://debugpointnews.com/author/dpicubegmail-com/
+[b]: https://github.com/lkxed/
+[1]: https://debugpointnews.com/wp-content/uploads/2023/05/Nitrux-2.8-desktop-live.jpg
+[2]: https://nxos.org/get/latest
+[3]: https://fosstorrents.com/distributions/nitrux/
+[4]: https://sourceforge.net/projects/nitruxos/files/Release/ISO
+[5]: https://osdn.net/projects/nitrux/releases/p18379
+[6]: https://nxos.org/notes/notes-nitrux-2-8-0/
+[7]: https://nxos.org/changelog/release-announcement-nitrux-2-8-0/
+[8]: https://floss.social/@debugpoint


### PR DESCRIPTION
This article is collected by lkxed.