### PR TITLE
translating

### DIFF
--- a/sources/tech/20230310.1 ⭐️⭐️ How the GDB debugger and other tools use call frame information to determine the active function calls.md
+++ b/sources/tech/20230310.1 ⭐️⭐️ How the GDB debugger and other tools use call frame information to determine the active function calls.md
@@ -2,7 +2,7 @@
 [#]: via: "https://opensource.com/article/23/3/gdb-debugger-call-frame-active-function-calls"
 [#]: author: "Will Cohen https://opensource.com/users/wcohen"
 [#]: collector: "lkxed"
-[#]: translator: " "
+[#]: translator: "jrglinux"
 [#]: reviewer: " "
 [#]: publisher: " "
 [#]: url: " "


### PR DESCRIPTION
translating

How the GDB debugger and other tools use call frame information to determine the active function calls